### PR TITLE
asciichart: correct off by 1 error

### DIFF
--- a/lib/mobius/asciichart.ex
+++ b/lib/mobius/asciichart.ex
@@ -65,7 +65,6 @@ defmodule Mobius.Asciichart do
         height = if cfg[:height], do: cfg[:height] - 1, else: interval
         padding = cfg[:padding] || " "
         ratio = if interval == 0, do: 1, else: height / interval
-
         min2 = safe_floor(minimum * ratio)
         max2 = safe_ceil(maximum * ratio)
 
@@ -102,7 +101,7 @@ defmodule Mobius.Asciichart do
           intmin2..intmax2
           |> Enum.reduce(result, fn y, map ->
             label =
-              (maximum - (y - intmin2) * interval / (rows + 1))
+              (maximum - (y - intmin2) * interval / (rows))
               |> Float.round(2)
               |> :erlang.float_to_binary(decimals: 2)
               |> String.pad_leading(label_size, padding)

--- a/lib/mobius/asciichart.ex
+++ b/lib/mobius/asciichart.ex
@@ -74,6 +74,8 @@ defmodule Mobius.Asciichart do
         rows = abs(intmax2 - intmin2)
         width = length(series) + offset
 
+        rows_denom = max(1, rows)
+
         # empty space
         result =
           0..(rows + 1)
@@ -101,7 +103,7 @@ defmodule Mobius.Asciichart do
           intmin2..intmax2
           |> Enum.reduce(result, fn y, map ->
             label =
-              (maximum - (y - intmin2) * interval / (rows))
+              (maximum - (y - intmin2) * interval / rows_denom)
               |> Float.round(2)
               |> :erlang.float_to_binary(decimals: 2)
               |> String.pad_leading(label_size, padding)

--- a/test/mobius/asciichart.exs
+++ b/test/mobius/asciichart.exs
@@ -1,0 +1,11 @@
+defmodule Mobius.AsciichartTest do
+  use ExUnit.Case, async: false
+
+  alias Mobius.Asciichart
+
+  test "Can generate a chart with nonvarying values" do
+    # Ensure that we don't blow up when creating a chart with a single row of unvarying values
+    assert {:ok, plot} = Asciichart.plot([1, 1, 1, 1])
+    assert plot == {:ok, "1.00 ┼───  \n        "}
+  end
+end


### PR DESCRIPTION
Value axis was frequently showing unnecessary float digits, caused by off by one in axis scaling

Fixes #32