### PR TITLE
Rename Mobius.name to Mobius.instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ any time. The public API SHOULD NOT be considered stable.
 * `Mobius.plot/3` is now `Mobius.Exports.plot/4`
 * `Mobius.to_csv/3` is now `Mobius.Exports.csv/4`
 * `Mobius.filter_metrics/3` is now `Mobius.Exports.metrics/4`
+* `Mobius.name()` is now `Mobius.instance()`
+*  Mobius functions that need to know the name of the mobius instance now
+  expect `:mobius_instance` and not `:name`
 
 ### Removed
 

--- a/lib/mobius/auto_save.ex
+++ b/lib/mobius/auto_save.ex
@@ -7,18 +7,18 @@ defmodule Mobius.AutoSave do
 
   @spec start_link([Mobius.arg()]) :: GenServer.on_start()
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: name(args[:name]))
+    GenServer.start_link(__MODULE__, args, name: name(args[:mobius_instance]))
   end
 
-  defp name(mobius_name) do
-    Module.concat(__MODULE__, mobius_name)
+  defp name(instance) do
+    Module.concat(__MODULE__, instance)
   end
 
   @impl GenServer
   def init(args) do
     state =
       args
-      |> Keyword.take([:autosave_interval, :name, :persistence_dir])
+      |> Keyword.take([:autosave_interval, :mobius_instance, :persistence_dir])
       |> Enum.into(%{})
 
     _ = :timer.send_interval(state.autosave_interval * 1_000, self(), :auto_save)
@@ -28,7 +28,7 @@ defmodule Mobius.AutoSave do
 
   @impl GenServer
   def handle_info(:auto_save, state) do
-    _ = Mobius.save(state.name)
+    _ = Mobius.save(state.mobius_instance)
     {:noreply, state}
   end
 end

--- a/lib/mobius/events.ex
+++ b/lib/mobius/events.ex
@@ -15,7 +15,7 @@ defmodule Mobius.Events do
   * `:metrics` - the list of metrics that Mobius is to listen for
   """
   @type handler_config() :: %{
-          table: Mobius.name(),
+          table: Mobius.instance(),
           metrics: [Metrics.t()]
         }
 

--- a/lib/mobius/exports.ex
+++ b/lib/mobius/exports.ex
@@ -26,7 +26,7 @@ defmodule Mobius.Exports do
   * `:to` - the unix timestamp, in seconds, to stop querying at
   """
   @type export_opt() ::
-          {:mobius_instance, atom()}
+          {:mobius_instance, Mobius.instance()}
           | {:from, integer()}
           | {:to, integer()}
           | {:last, integer() | {integer(), Mobius.time_unit()}}

--- a/lib/mobius/metrics_table/monitor.ex
+++ b/lib/mobius/metrics_table/monitor.ex
@@ -9,18 +9,18 @@ defmodule Mobius.MetricsTable.Monitor do
 
   @spec start_link([Mobius.arg()]) :: GenServer.on_start()
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: name(args[:name]))
+    GenServer.start_link(__MODULE__, args, name: name(args[:mobius_instance]))
   end
 
-  defp name(mobius_name) do
-    Module.concat(__MODULE__, mobius_name)
+  defp name(instance) do
+    Module.concat(__MODULE__, instance)
   end
 
   @doc """
   Persist the metrics to disk
   """
-  @spec save(Mobius.name()) :: :ok | {:error, reason :: term()}
-  def save(name), do: GenServer.call(name(name), :save)
+  @spec save(Mobius.instance()) :: :ok | {:error, reason :: term()}
+  def save(instance), do: GenServer.call(name(instance), :save)
 
   @impl GenServer
   def init(args) do
@@ -28,7 +28,7 @@ defmodule Mobius.MetricsTable.Monitor do
 
     state =
       args
-      |> Keyword.take([:name, :persistence_dir])
+      |> Keyword.take([:mobius_instance, :persistence_dir])
       |> Enum.into(%{})
 
     {:ok, state}
@@ -46,6 +46,6 @@ defmodule Mobius.MetricsTable.Monitor do
 
   # Write our ETS table to persistent storage
   defp save_to_persistence(state) do
-    MetricsTable.save(state.name, state.persistence_dir)
+    MetricsTable.save(state.mobius_instance, state.persistence_dir)
   end
 end

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -13,11 +13,11 @@ defmodule Mobius.Scraper do
   """
   @spec start_link([Mobius.arg()]) :: GenServer.on_start()
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: name(args[:name]))
+    GenServer.start_link(__MODULE__, args, name: name(args[:mobius_instance]))
   end
 
-  defp name(mobius_name) do
-    Module.concat(__MODULE__, mobius_name)
+  defp name(mobius_instance) do
+    Module.concat(__MODULE__, mobius_instance)
   end
 
   @typedoc """
@@ -31,16 +31,16 @@ defmodule Mobius.Scraper do
   @doc """
   Get all the records
   """
-  @spec all(Mobius.name(), [all_opt()]) :: [Mobius.record()]
-  def all(name, opts \\ []) do
-    GenServer.call(name(name), {:get, opts})
+  @spec all(Mobius.instance(), [all_opt()]) :: [Mobius.record()]
+  def all(instance, opts \\ []) do
+    GenServer.call(name(instance), {:get, opts})
   end
 
   @doc """
   Persist the metrics to disk
   """
-  @spec save(Mobius.name()) :: :ok | {:error, reason :: term()}
-  def save(name), do: GenServer.call(name(name), :save)
+  @spec save(Mobius.instance()) :: :ok | {:error, reason :: term()}
+  def save(instance), do: GenServer.call(name(instance), :save)
 
   @impl GenServer
   def init(args) do
@@ -57,7 +57,7 @@ defmodule Mobius.Scraper do
 
   defp state_from_args(args) do
     args
-    |> Keyword.take([:name, :persistence_dir])
+    |> Keyword.take([:mobius_instance, :persistence_dir])
     |> Enum.into(%{})
   end
 
@@ -115,7 +115,7 @@ defmodule Mobius.Scraper do
 
   @impl GenServer
   def handle_info(:scrape, state) do
-    case MetricsTable.get_entries(state.name) do
+    case MetricsTable.get_entries(state.mobius_instance) do
       [] ->
         {:noreply, state}
 

--- a/test/mobius/events_test.exs
+++ b/test/mobius/events_test.exs
@@ -6,7 +6,7 @@ defmodule Mobius.EventsTest do
 
   setup do
     table = :mobius_test_events
-    MetricsTable.init(name: table, persistence_dir: "/does/not/matter/here")
+    MetricsTable.init(mobius_instance: table, persistence_dir: "/does/not/matter/here")
 
     {:ok, %{table: table}}
   end

--- a/test/mobius/metrics/metrics_table_test.exs
+++ b/test/mobius/metrics/metrics_table_test.exs
@@ -5,7 +5,7 @@ defmodule Mobius.Metrics.MetricsTableTest do
 
   setup do
     table_name = :metrics_table_test_table
-    MetricsTable.init(name: table_name, persistence_dir: "/does/not/matter/here")
+    MetricsTable.init(mobius_instance: table_name, persistence_dir: "/does/not/matter/here")
 
     {:ok, %{table: table_name}}
   end

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -7,7 +7,7 @@ defmodule MobiusTest do
     persistence_dir: @persistence_dir,
     metrics: []
   ]
-  @default_name "mobius"
+  @default_instance_str "mobius"
 
   setup do
     File.rm_rf!(@persistence_dir)
@@ -19,7 +19,7 @@ defmodule MobiusTest do
   end
 
   test "does not crash with a corrupt history file" do
-    persistence_path = Path.join(@persistence_dir, @default_name)
+    persistence_path = Path.join(@persistence_dir, @default_instance_str)
     File.mkdir_p(persistence_path)
     File.write!(file(persistence_path), <<>>)
 
@@ -29,16 +29,16 @@ defmodule MobiusTest do
   end
 
   test "can save persistence data" do
-    persistence_path = Path.join(@persistence_dir, @default_name)
+    persistence_path = Path.join(@persistence_dir, @default_instance_str)
     {:ok, _pid} = start_supervised({Mobius, @default_args})
 
-    assert :ok = Mobius.save(@default_name)
+    assert :ok = Mobius.save(@default_instance_str)
     assert File.exists?(Path.join(persistence_path, "history"))
     assert File.exists?(Path.join(persistence_path, "metrics_table"))
   end
 
   test "can autosave persistence data" do
-    persistence_path = Path.join(@persistence_dir, @default_name)
+    persistence_path = Path.join(@persistence_dir, @default_instance_str)
     {:ok, _pid} = start_supervised({Mobius, @default_args ++ [autosave_interval: 1]})
     refute File.exists?(Path.join(persistence_path, "history"))
 


### PR DESCRIPTION
Rename the type `Mobius.name()` to be `Mobius.instance()`. Also this
changes the argument `:name` to be `:mobius_instance`.

The reason for this change was `:name` did not seem descriptive enough
and could easily be configured with metric name or some other idea of a
name.
