### PR TITLE
Refactor `Mobius.metric_name()` and metric name inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ any time. The public API SHOULD NOT be considered stable.
 * `Mobius.to_csv/3` is now `Mobius.Exports.csv/4`
 * `Mobius.filter_metrics/3` is now `Mobius.Exports.metrics/4`
 * `Mobius.name()` is now `Mobius.instance()`
-*  Mobius functions that need to know the name of the mobius instance now
-   expect `:mobius_instance` and not `:name`
+* Mobius functions that need to know the name of the mobius instance now
+  expect `:mobius_instance` and not `:name`
+* `Mobius.metric_name()` is no longer a list of `atoms()` but is not the metric
+  name as a string
 
 ### Removed
 
@@ -24,6 +26,9 @@ any time. The public API SHOULD NOT be considered stable.
 * `Mobius.csv_opt()` type
 * `Mobius.plot_opt()` type
 * `Mobius.query_opts/1` function
+* `Mobius.to_csv/3` function
+* `Mobius.plot/3` function
+* `Mobius.filter_metrics/3` function
 
 ### Added
 

--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -39,7 +39,12 @@ defmodule Mobius do
 
   @type metric_type() :: :counter | :last_value | :sum | :summary
 
-  @type metric_name() :: [atom()]
+  @typedoc """
+  The name of the metric
+
+  Example: `"vm.memory.total"`
+  """
+  @type metric_name() :: binary()
 
   @typedoc """
   A single metric data point
@@ -147,16 +152,16 @@ defmodule Mobius do
   def info(instance) do
     instance
     |> MetricsTable.get_entries()
-    |> Enum.group_by(fn {event_name, _type, _value, meta} -> {event_name, meta} end)
-    |> Enum.each(fn {{event_name, meta}, metrics} ->
+    |> Enum.group_by(fn {metric_name, _type, _value, meta} -> {metric_name, meta} end)
+    |> Enum.each(fn {{metric_name, meta}, metrics} ->
       reports =
-        Enum.map(metrics, fn {_event_name, type, value, _meta} ->
+        Enum.map(metrics, fn {_metric_name, type, value, _meta} ->
           "#{to_string(type)}: #{inspect(format_value(type, value))}\n"
         end)
 
       [
         "Metric Name: ",
-        Enum.join(event_name, "."),
+        metric_name,
         "\n",
         "Tags: #{inspect(meta)}\n",
         reports

--- a/lib/mobius/exports.ex
+++ b/lib/mobius/exports.ex
@@ -128,7 +128,7 @@ defmodule Mobius.Exports do
   Mobius.Exports.metrics("vm.memory.total", :last_value, %{}, last: {2, :hour})
   ```
   """
-  @spec metrics(binary(), Mobius.metric_type(), map(), [export_opt()] | keyword()) ::
+  @spec metrics(Mobius.metric_name(), Mobius.metric_type(), map(), [export_opt()] | keyword()) ::
           {:ok, [Mobius.metric()]} | {:error, UnsupportedMetricError.t()}
   def metrics(metric_name, type, tags, opts \\ [])
 
@@ -192,7 +192,7 @@ defmodule Mobius.Exports do
   Mobius.Export.plot("vm.memory.total", :last_value, %{}, last: {2, :hour})
   ```
   """
-  @spec plot(binary(), Mobius.metric_type(), map(), [export_opt()]) :: :ok
+  @spec plot(Mobius.metric_name(), Mobius.metric_type(), map(), [export_opt()]) :: :ok
   def plot(metric_name, type, tags \\ %{}, opts \\ []) do
     with {:ok, series} <- series(metric_name, type, tags, opts),
          {:ok, plot} <- Mobius.Asciichart.plot(series, height: 12) do

--- a/test/mobius/events_test.exs
+++ b/test/mobius/events_test.exs
@@ -13,37 +13,28 @@ defmodule Mobius.EventsTest do
 
   test "handles counter metric", %{table: table} do
     name = "events.test.count.me"
-    normalized_name = normalize_metric_name(name)
 
     config = %{
       table: table,
       metrics: [Metrics.counter("events.test.count.me")]
     }
 
-    :ok = Events.handle(Enum.take(normalized_name, 3), %{}, %{}, config)
+    :ok = Events.handle([:events, :test, :count], %{}, %{}, config)
 
-    assert [{^normalized_name, :counter, 1, %{}}] =
-             MetricsTable.get_entries_by_event_name(table, normalized_name)
+    assert [{^name, :counter, 1, %{}}] = MetricsTable.get_entries_by_metric_name(table, name)
   end
 
   test "handles last value metric", %{table: table} do
     name = "events.test.last.value"
-    normalized_name = normalize_metric_name(name)
 
     config = %{
       table: table,
       metrics: [Metrics.last_value("events.test.last.value")]
     }
 
-    :ok = Events.handle(Enum.take(normalized_name, 3), %{value: 1000}, %{}, config)
+    :ok = Events.handle([:events, :test, :last, :value], %{value: 1000}, %{}, config)
 
-    assert [{^normalized_name, :last_value, 1000, %{}}] =
-             MetricsTable.get_entries_by_event_name(table, normalized_name)
-  end
-
-  defp normalize_metric_name(metric_name) do
-    metric_name
-    |> String.split(".", trim: true)
-    |> Enum.map(&String.to_atom/1)
+    assert [{^name, :last_value, 1000, %{}}] =
+             MetricsTable.get_entries_by_metric_name(table, name)
   end
 end

--- a/test/mobius/metrics/metrics_table_test.exs
+++ b/test/mobius/metrics/metrics_table_test.exs
@@ -11,92 +11,92 @@ defmodule Mobius.Metrics.MetricsTableTest do
   end
 
   test "initialize counter on first update", %{table: table} do
-    :ok = MetricsTable.put(table, "counter event 1", :counter, 1)
+    :ok = MetricsTable.put(table, [:counter, :event, :hello], :counter, 1)
 
-    result = MetricsTable.get_entries_by_event_name(table, "counter event 1")
+    result = MetricsTable.get_entries_by_metric_name(table, "counter.event.hello")
 
-    assert result == [{"counter event 1", :counter, 1, %{}}]
+    assert result == [{"counter.event.hello", :counter, 1, %{}}]
   end
 
   test "increament counter after first report", %{table: table} do
-    :ok = MetricsTable.put(table, "counter event 2", :counter, 1)
-    :ok = MetricsTable.put(table, "counter event 2", :counter, 1)
+    :ok = MetricsTable.put(table, [:counter, :event, :world], :counter, 1)
+    :ok = MetricsTable.put(table, [:counter, :event, :world], :counter, 1)
 
-    result = MetricsTable.get_entries_by_event_name(table, "counter event 2")
+    result = MetricsTable.get_entries_by_metric_name(table, "counter.event.world")
 
-    assert result == [{"counter event 2", :counter, 2, %{}}]
+    assert result == [{"counter.event.world", :counter, 2, %{}}]
   end
 
   test "increament counter with inc_counter/3", %{table: table} do
-    event_name = "increament helper event"
+    metric_name = "increment.helper.event"
 
-    :ok = MetricsTable.inc_counter(table, event_name)
-    :ok = MetricsTable.inc_counter(table, event_name)
-    :ok = MetricsTable.inc_counter(table, event_name)
+    Enum.each(0..2, fn _ ->
+      :ok = MetricsTable.inc_counter(table, [:increment, :helper, :event])
+    end)
 
-    result = MetricsTable.get_entries_by_event_name(table, event_name)
+    result = MetricsTable.get_entries_by_metric_name(table, metric_name)
 
-    assert result == [{event_name, :counter, 3, %{}}]
+    assert result == [{metric_name, :counter, 3, %{}}]
   end
 
   test "initialize last value on first report", %{table: table} do
-    event_name = "last value event 1"
+    metric_name = "last.value.event.one"
 
-    :ok = MetricsTable.put(table, event_name, :last_value, 123)
+    :ok = MetricsTable.put(table, [:last, :value, :event, :one], :last_value, 123)
 
-    result = MetricsTable.get_entries_by_event_name(table, event_name)
+    result = MetricsTable.get_entries_by_metric_name(table, metric_name)
 
-    assert result == [{event_name, :last_value, 123, %{}}]
+    assert result == [{metric_name, :last_value, 123, %{}}]
   end
 
   test "update last value after first report", %{table: table} do
-    event_name = "last value event 2"
+    metric_name = "last.value.event.two"
 
-    :ok = MetricsTable.put(table, event_name, :last_value, 321)
-    :ok = MetricsTable.put(table, event_name, :last_value, 765)
+    :ok = MetricsTable.put(table, [:last, :value, :event, :two], :last_value, 321)
+    :ok = MetricsTable.put(table, [:last, :value, :event, :two], :last_value, 765)
 
-    result = MetricsTable.get_entries_by_event_name(table, event_name)
+    result = MetricsTable.get_entries_by_metric_name(table, metric_name)
 
-    assert result == [{event_name, :last_value, 765, %{}}]
+    assert result == [{metric_name, :last_value, 765, %{}}]
   end
 
   test "remove a metric from the metric table", %{table: table} do
-    event_name = "I will be removed"
-    :ok = MetricsTable.put(table, event_name, :last_value, 1000)
+    metric_name = "i.will.be.removed"
+    :ok = MetricsTable.put(table, [:i, :will, :be, :removed], :last_value, 1000)
 
     # ensure the metric is saved
-    assert [{event_name, :last_value, 1000, %{}}] ==
-             MetricsTable.get_entries_by_event_name(table, event_name)
+    assert [{metric_name, :last_value, 1000, %{}}] ==
+             MetricsTable.get_entries_by_metric_name(table, metric_name)
 
-    :ok = MetricsTable.remove(table, event_name, :last_value)
+    :ok = MetricsTable.remove(table, [:i, :will, :be, :removed], :last_value)
 
     # make sure removed
-    assert [] == MetricsTable.get_entries_by_event_name(table, event_name)
+    assert [] == MetricsTable.get_entries_by_metric_name(table, metric_name)
   end
 
   test "update a sum of values", %{table: table} do
     metric_name = "sum"
-    :ok = MetricsTable.update_sum(table, metric_name, 100)
+    :ok = MetricsTable.update_sum(table, [:sum], 100)
 
     assert [{metric_name, :sum, 100, %{}}] ==
-             MetricsTable.get_entries_by_event_name(table, metric_name)
+             MetricsTable.get_entries_by_metric_name(table, metric_name)
 
-    :ok = MetricsTable.update_sum(table, metric_name, 50)
+    :ok = MetricsTable.update_sum(table, [:sum], 50)
 
     assert [{metric_name, :sum, 150, %{}}] ==
-             MetricsTable.get_entries_by_event_name(table, metric_name)
+             MetricsTable.get_entries_by_metric_name(table, metric_name)
   end
 
   test "handle summary telemetry", %{table: table} do
     metric_name = "summary"
-    :ok = MetricsTable.put(table, metric_name, :summary, 100)
+    :ok = MetricsTable.put(table, [:summary], :summary, 100)
 
     assert [{^metric_name, :summary, %{accumulated: 100, max: 100, min: 100, reports: 1}, %{}}] =
-             MetricsTable.get_entries_by_event_name(table, metric_name)
+             MetricsTable.get_entries_by_metric_name(table, metric_name)
 
-    :ok = MetricsTable.put(table, metric_name, :summary, 120)
+    :ok = MetricsTable.put(table, [:summary], :summary, 120)
 
     assert [{^metric_name, :summary, %{accumulated: 220, max: 120, min: 100, reports: 2}, %{}}] =
-             MetricsTable.get_entries_by_event_name(table, metric_name)
+             MetricsTable.get_entries_by_metric_name(table, metric_name)
   end
 end


### PR DESCRIPTION
This refactoring cleared up a few inconsistencies with what Mobius
expected as a metric name. In some spots it will a list of atoms, like
what is exposed in the `:telemetry` library, and other cases the string
version of the metric name. Also, a few places called the metric name
the event name, which in reality those things are different.

This refactoring exposing functions that use the atom list metric name
for areas that directly interact with `:telemetry`. Also the atom list
name is stored in the metrics table, as it is easier to write match
specs on a list of atoms. Everything else a user of Mobius will see
exposes the metric name as a string.

This also allowed the marshalling between two formats to be consolidated
to one place.
