### PR TITLE
Remove min/max from summary metric output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > Major version zero (0.y.z) is for initial development. Anything MAY change at
 any time. The public API SHOULD NOT be considered stable.
 
+## Unreleased
+
+### Removed
+
+* Breaking change: `:min` and `:max` from summary metric output. These
+  values were never reset for the lifetime of the process, so a single
+  outlier would taint every later query.
+  They were more confusing than helpful and are removed.
+  The values are no longer returned from `Mobius.Exports.metrics/4` for the
+  `summary` type.
+
 ## [v0.7.0] - 2026-05-21
 
 ### Changed

--- a/lib/mobius/summary.ex
+++ b/lib/mobius/summary.ex
@@ -4,15 +4,13 @@ defmodule Mobius.Summary do
   @typedoc """
   Calculated summary statistics
   """
-  @type t() :: %{min: integer(), max: integer(), average: float(), std_dev: float()}
+  @type t() :: %{average: float(), std_dev: float()}
 
   @typedoc """
   A data type to store snapshot information about a summary in order
   to make calculations on at a later time
   """
   @type data() :: %{
-          min: integer(),
-          max: integer(),
           accumulated: integer(),
           accumulated_sqrd: integer(),
           reports: non_neg_integer()
@@ -24,8 +22,6 @@ defmodule Mobius.Summary do
   @spec new(integer()) :: data()
   def new(metric_value) do
     %{
-      min: metric_value,
-      max: metric_value,
       accumulated: metric_value,
       accumulated_sqrd: metric_value * metric_value,
       reports: 1
@@ -38,8 +34,6 @@ defmodule Mobius.Summary do
   @spec update(data(), integer()) :: data()
   def update(summary_data, new_metric_value) do
     %{
-      min: min(summary_data.min, new_metric_value),
-      max: max(summary_data.max, new_metric_value),
       accumulated: summary_data.accumulated + new_metric_value,
       accumulated_sqrd: summary_data.accumulated_sqrd + new_metric_value * new_metric_value,
       reports: summary_data.reports + 1
@@ -52,8 +46,6 @@ defmodule Mobius.Summary do
   @spec calculate(data()) :: t()
   def calculate(summary_data) do
     %{
-      min: summary_data.min,
-      max: summary_data.max,
       average: summary_data.accumulated / summary_data.reports,
       std_dev:
         std_dev(summary_data.accumulated, summary_data.accumulated_sqrd, summary_data.reports)

--- a/test/mobius/metrics/metrics_table_test.exs
+++ b/test/mobius/metrics/metrics_table_test.exs
@@ -91,12 +91,59 @@ defmodule Mobius.Metrics.MetricsTableTest do
     metric_name = "summary"
     :ok = MetricsTable.put(table, [:summary], :summary, 100)
 
-    assert [{^metric_name, :summary, %{accumulated: 100, max: 100, min: 100, reports: 1}, %{}}] =
+    assert [{^metric_name, :summary, %{accumulated: 100, reports: 1}, %{}}] =
              MetricsTable.get_entries_by_metric_name(table, metric_name)
 
     :ok = MetricsTable.put(table, [:summary], :summary, 120)
 
-    assert [{^metric_name, :summary, %{accumulated: 220, max: 120, min: 100, reports: 2}, %{}}] =
+    assert [{^metric_name, :summary, %{accumulated: 220, reports: 2}, %{}}] =
+             MetricsTable.get_entries_by_metric_name(table, metric_name)
+  end
+
+  # Persisted metrics tables from older Mobius versions contain summary entries
+  # with `:min` and `:max` keys. Loading those tables must still work — the
+  # unused keys should be ignored and subsequent updates should produce the
+  # current shape.
+  test "restore persisted summary entry that contains legacy :min/:max keys" do
+    persistence_dir =
+      Path.join(System.tmp_dir!(), "mobius_legacy_summary_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(persistence_dir)
+    on_exit(fn -> File.rm_rf!(persistence_dir) end)
+
+    table = :metrics_table_legacy_restore
+    :ets.new(table, [:named_table, :public, :set])
+
+    key = {[:legacy, :summary], :summary, %{}}
+
+    legacy_value = %{
+      reports: 2,
+      accumulated: 500,
+      accumulated_sqrd: 170_000,
+      min: 100,
+      max: 400
+    }
+
+    :ets.insert(table, {key, legacy_value})
+
+    :ok =
+      :ets.tab2file(table, String.to_charlist(Path.join(persistence_dir, "metrics_table")))
+
+    true = :ets.delete(table)
+
+    ^table = MetricsTable.init(mobius_instance: table, persistence_dir: persistence_dir)
+
+    metric_name = "legacy.summary"
+
+    assert [{^metric_name, :summary, ^legacy_value, %{}}] =
+             MetricsTable.get_entries_by_metric_name(table, metric_name)
+
+    :ok = MetricsTable.put(table, [:legacy, :summary], :summary, 200)
+
+    assert [
+             {^metric_name, :summary, %{accumulated: 700, accumulated_sqrd: 210_000, reports: 3},
+              %{}}
+           ] =
              MetricsTable.get_entries_by_metric_name(table, metric_name)
   end
 end

--- a/test/mobius/summary_test.exs
+++ b/test/mobius/summary_test.exs
@@ -7,9 +7,7 @@ defmodule Mobius.SummaryTest do
     expected_summary_data = %{
       reports: 1,
       accumulated: 100,
-      accumulated_sqrd: 10000,
-      min: 100,
-      max: 100
+      accumulated_sqrd: 10000
     }
 
     assert expected_summary_data == Summary.new(100)
@@ -19,16 +17,14 @@ defmodule Mobius.SummaryTest do
     expected_summary_data = %{
       reports: 1,
       accumulated: 100,
-      accumulated_sqrd: 10000,
-      min: 100,
-      max: 100
+      accumulated_sqrd: 10000
     }
 
     assert expected_summary_data == Summary.new(100)
   end
 
   test "calculate summary from summary data" do
-    expected_summary = %{min: 100, max: 400, average: 250.0, std_dev: 212.13203435596427}
+    expected_summary = %{average: 250.0, std_dev: 212.13203435596427}
 
     summary_data =
       100
@@ -36,5 +32,40 @@ defmodule Mobius.SummaryTest do
       |> Summary.update(400)
 
     assert expected_summary == Summary.calculate(summary_data)
+  end
+
+  # Persisted summary data from older versions of Mobius carried `:min` and
+  # `:max` keys. Loading that data must continue to work — the unused keys
+  # should be silently ignored.
+  describe "loading legacy summary data with :min/:max" do
+    test "calculate ignores legacy min/max keys" do
+      legacy_data = %{
+        reports: 2,
+        accumulated: 500,
+        accumulated_sqrd: 170_000,
+        min: 100,
+        max: 400
+      }
+
+      assert %{average: 250.0, std_dev: 212.13203435596427} ==
+               Summary.calculate(legacy_data)
+    end
+
+    test "update drops legacy min/max keys and keeps producing correct results" do
+      legacy_data = %{
+        reports: 1,
+        accumulated: 100,
+        accumulated_sqrd: 10_000,
+        min: 100,
+        max: 100
+      }
+
+      updated = Summary.update(legacy_data, 400)
+
+      assert updated == %{reports: 2, accumulated: 500, accumulated_sqrd: 170_000}
+
+      assert %{average: 250.0, std_dev: 212.13203435596427} ==
+               Summary.calculate(updated)
+    end
   end
 end


### PR DESCRIPTION
These values were never reset for the lifetime of the process, so a single outlier would taint every later query. They were never used internally for any computation, only propagated through, so drop them from the data, output, and tracking entirely.

Loading previously persisted summary data with `:min`/`:max` keys continues to work, the unused keys are ignored.

Closes #101