### PR TITLE
Rework record structure to reduce memory and disk usage

### DIFF
--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -108,6 +108,15 @@ defmodule Mobius do
           name: binary()
         }
 
+  @typedoc """
+  Packed metric record used in the in-memory RRD
+
+  This is the storage shape of a single metric inside a scrape snapshot. The
+  timestamp lives one level up on the snapshot itself, so the inner tuple only
+  carries identity (`name`, `tags`), `type`, and `value`.
+  """
+  @type record() :: {metric_name(), metric_type(), term(), map()}
+
   @type timestamp() :: integer()
 
   @doc """

--- a/lib/mobius/exports.ex
+++ b/lib/mobius/exports.ex
@@ -272,7 +272,8 @@ defmodule Mobius.Exports do
 
     mobius_instance
     |> Mobius.Scraper.all()
-    |> Enum.reject(fn metric -> metric.type == :summary end)
+    |> Enum.reject(fn {_ts, {_name, type, _value, _tags}} -> type == :summary end)
+    |> Enum.map(&Mobius.Scraper.to_metric/1)
     |> MobiusBinaryFormat.to_iodata()
     |> maybe_write_file(opts)
   end

--- a/lib/mobius/exports/metrics.ex
+++ b/lib/mobius/exports/metrics.ex
@@ -43,28 +43,37 @@ defmodule Mobius.Exports.Metrics do
     rows
   end
 
-  defp filter_metrics_for_metric(metrics, metric_name, :summary, tags) do
-    do_filter_metrics_for_metric(metrics, metric_name, :summary, tags)
-    |> Enum.map(fn metric ->
-      %{metric | value: metric.value |> Summary.calculate()}
+  defp filter_metrics_for_metric(records, metric_name, :summary, tags) do
+    records
+    |> do_filter_metrics_for_metric(metric_name, :summary, tags)
+    |> Enum.map(fn {ts, {name, type, value, tg}} ->
+      record_to_map({name, type, Summary.calculate(value), tg}, ts)
     end)
   end
 
-  defp filter_metrics_for_metric(metrics, metric_name, {:summary, summary_metric}, tags) do
-    do_filter_metrics_for_metric(metrics, metric_name, :summary, tags)
-    |> Enum.map(fn metric ->
-      %{metric | value: metric.value |> Summary.calculate() |> Map.get(summary_metric)}
+  defp filter_metrics_for_metric(records, metric_name, {:summary, summary_metric}, tags) do
+    records
+    |> do_filter_metrics_for_metric(metric_name, :summary, tags)
+    |> Enum.map(fn {ts, {name, type, value, tg}} ->
+      summarized = value |> Summary.calculate() |> Map.get(summary_metric)
+      record_to_map({name, type, summarized, tg}, ts)
     end)
   end
 
-  defp filter_metrics_for_metric(metrics, metric_name, type, tags) do
-    do_filter_metrics_for_metric(metrics, metric_name, type, tags)
+  defp filter_metrics_for_metric(records, metric_name, type, tags) do
+    records
+    |> do_filter_metrics_for_metric(metric_name, type, tags)
+    |> Enum.map(fn {ts, record} -> record_to_map(record, ts) end)
   end
 
-  defp do_filter_metrics_for_metric(metrics, metric_name, type, tags) do
-    Enum.filter(metrics, fn metric ->
-      metric_name == metric.name && match?(^tags, metric.tags) && type == metric.type
+  defp do_filter_metrics_for_metric(records, metric_name, type, tags) do
+    Enum.filter(records, fn {_ts, {name, rec_type, _value, rec_tags}} ->
+      metric_name == name && match?(^tags, rec_tags) && type == rec_type
     end)
+  end
+
+  defp record_to_map({name, type, value, tags}, ts) do
+    %{timestamp: ts, name: name, type: type, value: value, tags: tags}
   end
 
   defp query_opts(opts) do

--- a/lib/mobius/report_server.ex
+++ b/lib/mobius/report_server.ex
@@ -53,7 +53,10 @@ defmodule Mobius.ReportServer do
   def handle_call(:get_latest_metrics, _from, state) do
     {from, to} = get_query_window(state, :metrics)
 
-    metrics = Scraper.all(state.instance, from: from, to: to)
+    metrics =
+      state.instance
+      |> Scraper.all(from: from, to: to)
+      |> Enum.map(&Scraper.to_metric/1)
 
     {:reply, metrics, %{state | metrics_next_start: to + 1}}
   end

--- a/lib/mobius/rrd.ex
+++ b/lib/mobius/rrd.ex
@@ -32,9 +32,9 @@ defmodule Mobius.RRD do
   to study.
   """
 
-  require Logger
+  @serialization_version 3
 
-  @serialization_version 2
+  require Logger
 
   @opaque t() :: %{
             day: CircularBuffer.t(),
@@ -100,7 +100,7 @@ defmodule Mobius.RRD do
   @doc """
   Insert an item for the specified time
   """
-  @spec insert(t(), integer(), [Mobius.metric()]) :: t()
+  @spec insert(t(), integer(), [Mobius.record()]) :: t()
   def insert(rrd, ts, item) do
     value = {ts, item}
 
@@ -159,6 +159,16 @@ defmodule Mobius.RRD do
     data
     |> :erlang.binary_to_term()
     |> migrate_data(1)
+    |> migrate_data(2)
+    |> do_load(rrd)
+  catch
+    _, _ -> {:error, Mobius.DataLoadError.exception(reason: :corrupt, who: rrd)}
+  end
+
+  def load(rrd, <<2, data::binary>>) do
+    data
+    |> :erlang.binary_to_term()
+    |> migrate_data(2)
     |> do_load(rrd)
   catch
     _, _ -> {:error, Mobius.DataLoadError.exception(reason: :corrupt, who: rrd)}
@@ -185,7 +195,9 @@ defmodule Mobius.RRD do
     {:ok, loaded}
   end
 
-  # migrate data from version 1 to current
+  # migrate data from version 1 to version 2: turn dotted-list names into binaries
+  # and rewrite legacy tuple-shape records as 5-key maps so the v2 → v3 step can
+  # handle them uniformly.
   defp migrate_data(data, 1) do
     Enum.map(data, fn {timestamp, metrics} ->
       metrics =
@@ -198,13 +210,30 @@ defmodule Mobius.RRD do
     end)
   end
 
+  # migrate data from version 2 to version 3: drop the redundant inner
+  # `:timestamp` field and pack each record as a positional tuple.
+  defp migrate_data(data, 2) do
+    Enum.map(data, fn {timestamp, metrics} ->
+      metrics =
+        Enum.map(metrics, fn
+          %{name: name, type: type, value: value, tags: tags} ->
+            {name, type, value, tags}
+
+          {_name, _type, _value, _tags} = record ->
+            record
+        end)
+
+      {timestamp, metrics}
+    end)
+  end
+
   @typedoc """
   Options for saving RRD into a binary
 
   * `:serialization_version` - the version of serialization format, defaults to
     most recent
   """
-  @type save_opt() :: {:serialization_version, 1 | 2}
+  @type save_opt() :: {:serialization_version, 1 | 2 | 3}
 
   @doc """
   Serialize to an iolist
@@ -219,7 +248,7 @@ defmodule Mobius.RRD do
   @doc """
   Return all items in order
   """
-  @spec all(t()) :: [{Mobius.timestamp(), [Mobius.metric()]}]
+  @spec all(t()) :: [{Mobius.timestamp(), [Mobius.record()]}]
   def all(rrd) do
     result =
       CircularBuffer.to_list(rrd.day) ++

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -31,8 +31,12 @@ defmodule Mobius.Scraper do
 
   @doc """
   Get all the records
+
+  Returns a flat list of `{timestamp, record}` pairs, where `record` is a packed
+  `{name, type, value, tags}` tuple. Callers that need the public
+  `t:Mobius.metric/0` map shape should pipe through `to_metric/1`.
   """
-  @spec all(Mobius.instance(), [all_opt()]) :: [Mobius.metric()]
+  @spec all(Mobius.instance(), [all_opt()]) :: [{Mobius.timestamp(), Mobius.record()}]
   def all(instance, opts \\ []) do
     GenServer.call(name(instance), {:get, opts})
   end
@@ -90,9 +94,17 @@ defmodule Mobius.Scraper do
   end
 
   defp to_metrics_list(timestamped_metrics) do
-    Enum.flat_map(timestamped_metrics, fn {_, metrics} ->
-      metrics
+    Enum.flat_map(timestamped_metrics, fn {ts, records} ->
+      Enum.map(records, fn record -> {ts, record} end)
     end)
+  end
+
+  @doc """
+  Materialize a packed record (and its timestamp) into a `Mobius.metric/0` map
+  """
+  @spec to_metric({Mobius.timestamp(), Mobius.record()}) :: Mobius.metric()
+  def to_metric({ts, {name, type, value, tags}}) do
+    %{timestamp: ts, name: name, type: type, value: value, tags: tags}
   end
 
   @impl GenServer
@@ -135,7 +147,6 @@ defmodule Mobius.Scraper do
 
       scrape ->
         ts = System.system_time(:second)
-        scrape = scrape_to_metrics_list(ts, scrape)
         database = RRD.insert(state.database, ts, scrape)
 
         {:noreply, %{state | database: database}}
@@ -149,18 +160,6 @@ defmodule Mobius.Scraper do
   @impl GenServer
   def terminate(_reason, state) do
     save_to_persistence(state)
-  end
-
-  defp scrape_to_metrics_list(ts, scrape) do
-    Enum.map(scrape, fn {name, type, value, tags} ->
-      %{
-        timestamp: ts,
-        name: name,
-        type: type,
-        value: value,
-        tags: tags
-      }
-    end)
   end
 
   # Write our database to persistent storage

--- a/test/mobius/rrd_test.exs
+++ b/test/mobius/rrd_test.exs
@@ -44,19 +44,15 @@ defmodule Mobius.RRDTest do
 
       expected_rrd =
         RRD.new(@args)
-        |> RRD.insert(1234, [
-          %{name: "vm.memory.total", type: :last_value, value: 123, tags: %{}, timestamp: 1234}
-        ])
-        |> RRD.insert(3000, [
-          %{name: "vm.memory.total", type: :last_value, value: 124, tags: %{}, timestamp: 3000}
-        ])
+        |> RRD.insert(1234, [{"vm.memory.total", :last_value, 123, %{}}])
+        |> RRD.insert(3000, [{"vm.memory.total", :last_value, 124, %{}}])
 
       in_rrd_binary = RRD.save(in_rrd, serialization_version: 1) |> IO.iodata_to_binary()
       assert RRD.load(RRD.new(@args), in_rrd_binary) == {:ok, expected_rrd}
     end
 
-    test "version 2" do
-      rrd =
+    test "version 2 (legacy map-shape records)" do
+      v2_in_rrd =
         RRD.new(@args)
         |> RRD.insert(1234, [
           %{name: "vm.memory.total", type: :last_value, value: 123, tags: %{}, timestamp: 1234}
@@ -64,6 +60,21 @@ defmodule Mobius.RRDTest do
         |> RRD.insert(3000, [
           %{name: "vm.memory.total", type: :last_value, value: 124, tags: %{}, timestamp: 3000}
         ])
+
+      expected_rrd =
+        RRD.new(@args)
+        |> RRD.insert(1234, [{"vm.memory.total", :last_value, 123, %{}}])
+        |> RRD.insert(3000, [{"vm.memory.total", :last_value, 124, %{}}])
+
+      v2_binary = RRD.save(v2_in_rrd, serialization_version: 2) |> IO.iodata_to_binary()
+      assert RRD.load(RRD.new(@args), v2_binary) == {:ok, expected_rrd}
+    end
+
+    test "version 3" do
+      rrd =
+        RRD.new(@args)
+        |> RRD.insert(1234, [{"vm.memory.total", :last_value, 123, %{}}])
+        |> RRD.insert(3000, [{"vm.memory.total", :last_value, 124, %{}}])
 
       rrd_binary = RRD.save(rrd) |> IO.iodata_to_binary()
       assert RRD.load(RRD.new(@args), rrd_binary) == {:ok, rrd}


### PR DESCRIPTION
Each scrape snapshot stored in the RRD used to hold its metrics as 5-key maps (`%{timestamp:, name:, type:, value:, tags:}`). The map structure leads to memory overhead. There are also redundant timestamps.

This commit replaces the map with a `{name, type, value, tags}` tuple and drop the redundant inner timestamp. For a typical 10-metric instance at default retention (348 snapshots), the heap held by record maps drops from ~835 KB to ~500 KB.
Savings scale linearly with metric count and retention.

The change primarily affects in-memory and disk storage. `Mobius.Exports.metrics/4`, the MBF binary format, the CSV exporter, and `Mobius.get_latest_metrics/1` all keep returning maps.

Adds data migration for persisted data from v2 -> v3. the migration ladder converts on-disk data into the new tuple shape on load.

This would not be worth the breaking change if it wasn't for upcoming work. The upcoming histogram sees massive savings from avoiding these redundant keys and values. This work is intended to ensure we use the same structure for both data types.