### PR TITLE
Compress persisted data

### DIFF
--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -11,7 +11,12 @@ defmodule Mobius do
 
   require Logger
 
-  @default_args [mobius_instance: :mobius, persistence_dir: "/data", autosave_interval: nil]
+  @default_args [
+    mobius_instance: :mobius,
+    persistence_dir: "/data",
+    autosave_interval: nil,
+    compression_level: 9
+  ]
 
   @type time_unit() :: :second | :minute | :hour | :day
 
@@ -49,6 +54,10 @@ defmodule Mobius do
   * `:persistence_dir` - the top level directory where mobius will persist
   * `:autosave_interval` - time in seconds between automatic writes of the
      persistence data (default disabled) metric information
+  * `:compression_level` - the zlib level (`0..9`) used when compressing
+     persisted metric history and event log data. Higher levels trade more CPU
+     at save time for smaller files. Defaults to `9` (maximum compression). `0`
+     disables compression.
   * `:database` - the `Mobius.RRD.t()` to use. This will default to the default
      values found in `Mobius.RRD`
   * `:events` - a list of events for mobius to store in the event log
@@ -69,6 +78,7 @@ defmodule Mobius do
           {:mobius_instance, instance()}
           | {:metrics, [Metrics.t()]}
           | {:persistence_dir, binary()}
+          | {:compression_level, 0..9}
           | {:database, Mobius.RRD.t()}
           | {:events, [event_def()]}
           | {:event_log_size, integer()}

--- a/lib/mobius/event_log.ex
+++ b/lib/mobius/event_log.ex
@@ -6,6 +6,7 @@ defmodule Mobius.EventLog do
   alias Mobius.{Event, EventsServer}
 
   @event_log_binary_format_version 1
+  @default_compression_level 9
 
   @typedoc """
   Options to query the event log
@@ -21,35 +22,46 @@ defmodule Mobius.EventLog do
     EventsServer.list(instance, opts)
   end
 
+  @typedoc """
+  Options for serializing the event log
+
+  * `:compression_level` - the zlib level (`0..9`) used to compress the payload,
+    defaults to `9`. `0` disables compression.
+  """
+  @type serialize_opt() :: {:compression_level, 0..9}
+
   @doc """
   Return the event log in the Mobius binary format
   """
-  @spec to_binary([opt()]) :: binary()
+  @spec to_binary([opt() | serialize_opt()]) :: binary()
   def to_binary(opts \\ []) do
     opts
     |> list()
-    |> events_to_binary()
+    |> events_to_binary(opts)
   end
 
   @doc """
   Turn a list of Events into a binary
   """
-  @spec events_to_binary([Event.t()]) :: binary()
-  def events_to_binary(events) do
-    bin = :erlang.term_to_binary(events)
+  @spec events_to_binary([Event.t()], [serialize_opt()]) :: binary()
+  def events_to_binary(events, opts \\ []) do
+    compression_level = opts[:compression_level] || @default_compression_level
+    bin = :erlang.term_to_binary(events, [{:compressed, compression_level}])
 
     <<@event_log_binary_format_version, bin::binary>>
   end
 
   @doc """
   Save the current state of the event log to disk
+
+  The configured compression level for the instance is applied by the events
+  server when it writes the file.
   """
   @spec save([opt()]) :: :ok
   def save(opts \\ []) do
     instance = opts[:instance] || :mobius
-    bin = to_binary(opts)
 
-    EventsServer.save(instance, bin)
+    EventsServer.save(instance)
   end
 
   @doc """

--- a/lib/mobius/events_server.ex
+++ b/lib/mobius/events_server.ex
@@ -41,9 +41,9 @@ defmodule Mobius.EventsServer do
   @doc """
   Save the event log to disk
   """
-  @spec save(Mobius.instance(), binary()) :: :ok
-  def save(instance \\ :mobius, binary) do
-    GenServer.call(name(instance), {:save, binary})
+  @spec save(Mobius.instance()) :: :ok
+  def save(instance \\ :mobius) do
+    GenServer.call(name(instance), :save)
   end
 
   @doc """
@@ -70,7 +70,8 @@ defmodule Mobius.EventsServer do
        persistence_dir: persistence_dir,
        size: event_log_size,
        out_of_time_buffer: out_of_time_buffer,
-       instance: args[:mobius_instance]
+       instance: args[:mobius_instance],
+       compression_level: args[:compression_level] || 9
      }}
   end
 
@@ -106,10 +107,8 @@ defmodule Mobius.EventsServer do
   # Synchronous so callers (and Mobius.save/1) only see :ok once the event
   # log is actually on disk — otherwise the write races a caller that reads
   # or removes the persistence dir right after save returns.
-  def handle_call({:save, binary}, _from, state) do
-    :ok = do_save(binary, state)
-
-    {:reply, :ok, state}
+  def handle_call(:save, _from, state) do
+    {:reply, persist(state), state}
   end
 
   @impl GenServer
@@ -170,8 +169,12 @@ defmodule Mobius.EventsServer do
 
   @impl GenServer
   def terminate(_reason, state) do
+    persist(state)
+  end
+
+  defp persist(state) do
     events = make_list(state.buffer, [])
-    bin = EventLog.events_to_binary(events)
+    bin = EventLog.events_to_binary(events, compression_level: state.compression_level)
 
     do_save(bin, state)
   end

--- a/lib/mobius/rrd.ex
+++ b/lib/mobius/rrd.ex
@@ -33,6 +33,7 @@ defmodule Mobius.RRD do
   """
 
   @serialization_version 3
+  @default_compression_level 9
 
   require Logger
 
@@ -393,10 +394,13 @@ defmodule Mobius.RRD do
   * `:histogram_configs` - the resolved sketch configuration per
     histogram-enabled metric, recorded in v3 files so `load/3` can detect
     histogram data produced under a different configuration
+  * `:compression_level` - the zlib level (`0..9`) used to compress the payload,
+    defaults to `9`. `0` disables compression.
   """
   @type save_opt() ::
           {:serialization_version, 1 | 2 | 3}
           | {:histogram_configs, %{histogram_config_key() => map()}}
+          | {:compression_level, 0..9}
 
   @doc """
   Serialize to an iolist
@@ -404,6 +408,7 @@ defmodule Mobius.RRD do
   @spec save(t(), [save_opt()]) :: iolist()
   def save(rrd, opts \\ []) do
     serialization_version = opts[:serialization_version] || @serialization_version
+    compression_level = opts[:compression_level] || @default_compression_level
 
     payload =
       if serialization_version >= 3 do
@@ -412,7 +417,7 @@ defmodule Mobius.RRD do
         all(rrd)
       end
 
-    [serialization_version, :erlang.term_to_iovec(payload)]
+    [serialization_version, :erlang.term_to_binary(payload, [{:compressed, compression_level}])]
   end
 
   @doc """

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -67,7 +67,10 @@ defmodule Mobius.Scraper do
     # relative_accuracy).
     args
     |> Keyword.take([:mobius_instance, :persistence_dir])
-    |> Enum.into(%{histogram_configs: Events.histogram_configs(args[:metrics] || [])})
+    |> Enum.into(%{
+      histogram_configs: Events.histogram_configs(args[:metrics] || []),
+      compression_level: args[:compression_level] || 9
+    })
   end
 
   defp make_database(state, args) do
@@ -265,7 +268,13 @@ defmodule Mobius.Scraper do
   defp save_to_persistence(state) do
     path = file(state)
     tmp = path <> ".tmp"
-    contents = RRD.save(state.database, histogram_configs: state.histogram_configs)
+
+    contents =
+      RRD.save(state.database,
+        histogram_configs: state.histogram_configs,
+        compression_level: state.compression_level
+      )
+
     _ = File.mkdir_p(state.persistence_dir)
 
     result =

--- a/test/mobius/event_log_test.exs
+++ b/test/mobius/event_log_test.exs
@@ -23,7 +23,7 @@ defmodule Mobius.EventLogTest do
   end
 
   @tag :tmp_dir
-  test "to binary works (version 1)", %{tmp_dir: tmp_dir} do
+  test "to_binary round-trips through parse/1", %{tmp_dir: tmp_dir} do
     events = [
       Event.new("test", "a.b.c", 123_123, %{a: 1}, %{}),
       Event.new("test", "d.e.f", 123_124, %{a: 1}, %{})
@@ -31,11 +31,10 @@ defmodule Mobius.EventLogTest do
 
     load_event_log(:to_binary_works, tmp_dir, events)
 
-    expected_bin = <<0x01, :erlang.term_to_binary(events)::binary>>
-
     bin = EventLog.to_binary(instance: :to_binary_works)
 
-    assert bin == expected_bin
+    assert <<0x01, _payload::binary>> = bin
+    assert {:ok, ^events} = EventLog.parse(bin)
   end
 
   test "parses version 1" do
@@ -77,6 +76,17 @@ defmodule Mobius.EventLogTest do
     start_supervised!({Mobius, mobius_instance: instance, persistence_dir: tmp_dir})
 
     assert EventLog.list(instance: instance) == events
+  end
+
+  test "parse/1 accepts uncompressed v1 payloads (backwards compat)" do
+    events = [
+      Event.new("test", "a.b.c", 123_123, %{a: 1}, %{}),
+      Event.new("test", "d.e.f", 123_124, %{a: 1}, %{})
+    ]
+
+    bin = <<0x01, :erlang.term_to_binary(events)::binary>>
+
+    assert {:ok, ^events} = EventLog.parse(bin)
   end
 
   defp load_event_log(log_name, dir, events) do

--- a/test/mobius/rrd_test.exs
+++ b/test/mobius/rrd_test.exs
@@ -195,6 +195,42 @@ defmodule Mobius.RRDTest do
 
       assert RRD.load(RRD.new(@args), rrd_binary, histogram_configs: %{}) == {:ok, expected_rrd}
     end
+
+    test "compression_level changes the payload size but round-trips either way" do
+      # redundant data so compression has something to work with
+      rrd =
+        Enum.reduce(1..120, RRD.new(@args), fn ts, acc ->
+          RRD.insert(acc, ts, [{"vm.memory.total", :last_value, rem(ts, 10), %{}}])
+        end)
+
+      uncompressed = RRD.save(rrd, compression_level: 0) |> IO.iodata_to_binary()
+      compressed = RRD.save(rrd, compression_level: 9) |> IO.iodata_to_binary()
+
+      assert byte_size(compressed) < byte_size(uncompressed)
+      assert RRD.load(RRD.new(@args), uncompressed) == {:ok, rrd}
+      assert RRD.load(RRD.new(@args), compressed) == {:ok, rrd}
+    end
+
+    test "loads uncompressed v2 payloads (backwards compat)" do
+      v2_in_rrd =
+        RRD.new(@args)
+        |> RRD.insert(1234, [
+          %{name: "vm.memory.total", type: :last_value, value: 123, tags: %{}, timestamp: 1234}
+        ])
+        |> RRD.insert(3000, [
+          %{name: "vm.memory.total", type: :last_value, value: 124, tags: %{}, timestamp: 3000}
+        ])
+
+      expected_rrd =
+        RRD.new(@args)
+        |> RRD.insert(1234, {[{"vm.memory.total", :last_value, 123, %{}}], %{}})
+        |> RRD.insert(3000, {[{"vm.memory.total", :last_value, 124, %{}}], %{}})
+
+      uncompressed_binary =
+        IO.iodata_to_binary([2, :erlang.term_to_binary(RRD.all(v2_in_rrd))])
+
+      assert RRD.load(RRD.new(@args), uncompressed_binary) == {:ok, expected_rrd}
+    end
   end
 
   test "fails to load corrupt binaries" do


### PR DESCRIPTION
In tests we could see massive reductions in disk usage by compressing data before persisting. In the ballpark of 60-140x less storage used.

Other parallel work is reducing the large amount of redundant data so expect a smaller improvement after that work lands.

`:erlang.binary_to_term/1` is backwards-compatible and transparently accepts both compressed and uncompressed payloads, so the leading version byte stays the same and existing on-disk files keep loading. Backwards-compatibility tests added for both formats.