### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ def start(_type, _args) do
     # ... other children ....
   ]
 
-  # See https://hexdocs.pm/elixir/Supervisor.html
+  # See https://elixir.hexdocs.pm/Supervisor.html
   # for other strategies and supported options
   opts = [strategy: :one_for_one, name: MyApp.Supervisor]
   Supervisor.start_link(children, opts)
@@ -116,7 +116,7 @@ def start(_type, _args) do
     # ... other children ....
   ]
 
-  # See https://hexdocs.pm/elixir/Supervisor.html
+  # See https://elixir.hexdocs.pm/Supervisor.html
   # for other strategies and supported options
   opts = [strategy: :one_for_one, name: MyApp.Supervisor]
   Supervisor.start_link(children, opts)

--- a/example/README.md
+++ b/example/README.md
@@ -17,5 +17,5 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/example](https://hexdocs.pm/example).
+be found at [https://example.hexdocs.pm](https://hexdocs.pm/example).
 

--- a/example/lib/example/application.ex
+++ b/example/lib/example/application.ex
@@ -1,5 +1,5 @@
 defmodule Example.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -30,7 +30,7 @@ defmodule Example.Application do
        remote_report_interval: 10_000}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Example.Supervisor]
     Supervisor.start_link(children, opts)


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://example.hexdocs.pm](https://hexdocs.pm/example): %Req.TransportError{reason: :nxdomain}
⚠️ Verification finished: 2 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>