### PR TITLE
Write persistence files atomically

### DIFF
--- a/lib/mobius/events_server.ex
+++ b/lib/mobius/events_server.ex
@@ -193,21 +193,31 @@ defmodule Mobius.EventsServer do
   end
 
   defp do_save(binary, state) do
-    # The persistence directory may have been unavailable at boot (or gone
-    # away since) — re-create it on every attempt so saving recovers as
-    # soon as the filesystem allows.
+    # Write-to-tmp + fsync + rename so a power cut mid-write leaves the
+    # previous event log intact instead of a truncated one. The persistence
+    # directory may have been unavailable at boot (or gone away since), so
+    # re-create it on every attempt — saving recovers as soon as the
+    # filesystem allows.
     _ = File.mkdir_p(state.persistence_dir)
     path = make_file_path(state.persistence_dir)
+    tmp = path <> ".tmp"
 
-    _ =
-      case File.write(path, binary) do
-        :ok ->
-          state
-
-        {:error, reason} ->
-          Logger.warning("[Mobius]: unable to save event log: #{inspect(reason)}")
+    result =
+      with {:ok, fd} <- File.open(tmp, [:write, :binary]),
+           :ok <- IO.binwrite(fd, binary),
+           :ok <- :file.sync(fd),
+           :ok <- File.close(fd) do
+        File.rename(tmp, path)
       end
 
-    :ok
+    case result do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        _ = File.rm(tmp)
+        Logger.warning("[Mobius]: unable to save event log: #{inspect(reason)}")
+        :ok
+    end
   end
 end

--- a/lib/mobius/metrics_table.ex
+++ b/lib/mobius/metrics_table.ex
@@ -110,16 +110,20 @@ defmodule Mobius.MetricsTable do
   @doc """
   Save the ets table to a file
 
-  The persistence directory may have been unavailable at boot (or gone
-  away since) — re-create it on every attempt so saving recovers as soon
-  as the filesystem allows.
+  Dumps to a tmp file (synced) and renames it into place, so a power cut
+  mid-write cannot corrupt the previous dump. The persistence directory may
+  have been unavailable at boot (or gone away since), so re-create it on
+  every attempt — saving recovers as soon as the filesystem allows.
   """
   @spec save(Mobius.instance(), Path.t()) :: :ok | {:error, reason :: term()}
   def save(instance, persistence_dir) do
     _ = File.mkdir_p(persistence_dir)
-    file = String.to_charlist("#{persistence_dir}/metrics_table")
+    path = Path.join(persistence_dir, "metrics_table")
+    tmp = path <> ".tmp"
 
-    :ets.tab2file(instance, file)
+    with :ok <- :ets.tab2file(instance, String.to_charlist(tmp), sync: true) do
+      File.rename(tmp, path)
+    end
   end
 
   @doc """

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -257,18 +257,31 @@ defmodule Mobius.Scraper do
     save_to_persistence(state)
   end
 
-  # Write our database to persistent storage. The persistence directory may
-  # have been unavailable at boot (or gone away since) — re-create it on
-  # every attempt so saving recovers as soon as the filesystem allows.
+  # Write our database to persistent storage. Write-to-tmp + fsync + rename so a
+  # power cut mid-write leaves the previous file intact instead of a truncated one
+  # the next boot cannot load (and would then overwrite on its first autosave).
+  # The persistence directory may have been unavailable at boot (or gone away
+  # since), so re-create it on every attempt.
   defp save_to_persistence(state) do
+    path = file(state)
+    tmp = path <> ".tmp"
     contents = RRD.save(state.database, histogram_configs: state.histogram_configs)
     _ = File.mkdir_p(state.persistence_dir)
 
-    case File.write(file(state), contents) do
+    result =
+      with {:ok, fd} <- File.open(tmp, [:write, :binary]),
+           :ok <- IO.binwrite(fd, contents),
+           :ok <- :file.sync(fd),
+           :ok <- File.close(fd) do
+        File.rename(tmp, path)
+      end
+
+    case result do
       :ok ->
         :ok
 
       error ->
+        _ = File.rm(tmp)
         Logger.warning("Failed to save metrics history because #{inspect(error)}")
 
         error

--- a/test/mobius/event_log_test.exs
+++ b/test/mobius/event_log_test.exs
@@ -51,6 +51,34 @@ defmodule Mobius.EventLogTest do
     assert event_log == events
   end
 
+  @tag :tmp_dir
+  test "save persists the event log so a fresh instance restores it", %{tmp_dir: tmp_dir} do
+    instance = :event_log_roundtrip
+
+    events = [
+      Event.new("test", "a.b.c", %{a: 1}, %{}, timestamp: 1),
+      Event.new("test", "d.e.f", %{a: 2}, %{}, timestamp: 2)
+    ]
+
+    start_supervised!({Mobius, mobius_instance: instance, persistence_dir: tmp_dir})
+    Enum.each(events, fn event -> EventsServer.insert(instance, event) end)
+
+    assert :ok = EventLog.save(instance: instance)
+
+    # The dump landed at the real path with no temp file left behind.
+    # Mobius nests persistence under a per-instance subdirectory.
+    persistence_path = Path.join(tmp_dir, to_string(instance))
+    assert File.exists?(Path.join(persistence_path, "event_log"))
+    refute File.exists?(Path.join(persistence_path, "event_log.tmp"))
+
+    stop_supervised!(Mobius)
+
+    # A fresh instance pointed at the same dir recovers the events from disk.
+    start_supervised!({Mobius, mobius_instance: instance, persistence_dir: tmp_dir})
+
+    assert EventLog.list(instance: instance) == events
+  end
+
   defp load_event_log(log_name, dir, events) do
     start_supervised!({Mobius, mobius_instance: log_name, persistence_dir: dir})
 

--- a/test/mobius/metrics/metrics_table_test.exs
+++ b/test/mobius/metrics/metrics_table_test.exs
@@ -100,6 +100,32 @@ defmodule Mobius.Metrics.MetricsTableTest do
              MetricsTable.get_entries_by_metric_name(table, metric_name)
   end
 
+  test "save/2 persists the table so init/1 can restore it" do
+    persistence_dir =
+      Path.join(System.tmp_dir!(), "mobius_save_roundtrip_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(persistence_dir)
+    on_exit(fn -> File.rm_rf!(persistence_dir) end)
+
+    table = :metrics_table_save_roundtrip
+    ^table = MetricsTable.init(mobius_instance: table, persistence_dir: persistence_dir)
+
+    :ok = MetricsTable.put(table, [:saved, :value], :last_value, 42)
+
+    assert :ok = MetricsTable.save(table, persistence_dir)
+
+    # The dump landed at the real path and no temp file was left behind.
+    assert File.exists?(Path.join(persistence_dir, "metrics_table"))
+    refute File.exists?(Path.join(persistence_dir, "metrics_table.tmp"))
+
+    true = :ets.delete(table)
+
+    ^table = MetricsTable.init(mobius_instance: table, persistence_dir: persistence_dir)
+
+    assert [{"saved.value", :last_value, 42, %{}}] ==
+             MetricsTable.get_entries_by_metric_name(table, "saved.value")
+  end
+
   # Persisted metrics tables from older Mobius versions contain summary entries
   # with `:min` and `:max` keys. Loading those tables must still work — the
   # unused keys should be ignored and subsequent updates should produce the

--- a/test/mobius/scraper_test.exs
+++ b/test/mobius/scraper_test.exs
@@ -1,0 +1,64 @@
+defmodule Mobius.ScraperTest do
+  use ExUnit.Case, async: true
+
+  alias Mobius.{MetricsTable, RRD, Scraper}
+
+  @rrd_args [days: 60, hours: 48, minutes: 120, seconds: 120]
+
+  setup do
+    persistence_dir =
+      Path.join(System.tmp_dir!(), "mobius_scraper_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(persistence_dir)
+    on_exit(fn -> File.rm_rf!(persistence_dir) end)
+
+    {:ok, persistence_dir: persistence_dir}
+  end
+
+  defp start_scraper(instance, persistence_dir, database) do
+    # The scrape timer reads from a metrics table named after the instance, so
+    # make sure it exists before the scraper starts.
+    if :ets.whereis(instance) == :undefined do
+      MetricsTable.init(mobius_instance: instance, persistence_dir: persistence_dir)
+    end
+
+    args = [
+      mobius_instance: instance,
+      persistence_dir: persistence_dir,
+      database: database
+    ]
+
+    pid = start_supervised!({Scraper, args})
+    {pid, instance}
+  end
+
+  test "save/1 persists the database so a fresh scraper restores it", %{
+    persistence_dir: persistence_dir
+  } do
+    instance = :scraper_roundtrip
+
+    database =
+      RRD.new(@rrd_args)
+      |> RRD.insert(1234, [{"vm.memory.total", :last_value, 123, %{}}])
+      |> RRD.insert(3000, [{"vm.memory.total", :last_value, 124, %{}}])
+
+    {_pid, ^instance} = start_scraper(instance, persistence_dir, database)
+
+    assert :ok = Scraper.save(instance)
+
+    # File landed at the real path with no temp file left behind.
+    assert File.exists?(Path.join(persistence_dir, "history"))
+    refute File.exists?(Path.join(persistence_dir, "history.tmp"))
+
+    stop_supervised!(Scraper)
+
+    # A new scraper pointed at the same dir loads an empty database, then
+    # recovers the persisted records from disk.
+    {_pid, ^instance} = start_scraper(instance, persistence_dir, RRD.new(@rrd_args))
+
+    assert [
+             {1234, {"vm.memory.total", :last_value, 123, %{}}},
+             {3000, {"vm.memory.total", :last_value, 124, %{}}}
+           ] == Scraper.all(instance)
+  end
+end


### PR DESCRIPTION
A hard power-off mid-write left a truncated history/metrics_table that the next boot could not load (:unsupported_version / :badfile), after which the first autosave overwrote the remains losing all recorded history.

New approach: Dump to a tmp file, fsync, and rename into place as an atomic operation so a crash leaves the previous good file.