### PR TITLE
Add remove_all_data to clear all Mobius state (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ any time. The public API SHOULD NOT be considered stable.
 
 ### Added
 
-* `Mobius.reset/0` and `Mobius.reset/1` to clear everything out and return
-  Mobius to a clean state without a restart: the in-memory metrics table,
-  the accumulated history (RRD), the event log, and the persisted files on
-  disk (`history`, `metrics_table`, and `event_log`). Configured metrics
-  and events keep being tracked, so collection resumes immediately. Useful
-  when repurposing a device whose historical data is no longer meaningful,
-  or while debugging and developing.
+* `Mobius.remove_all_data/0` and `Mobius.remove_all_data/1` to clear
+  everything out and return Mobius to a clean state without a restart: the
+  in-memory metrics table, the accumulated history (RRD), the event log,
+  and the persisted files on disk (`history`, `metrics_table`, and
+  `event_log`). Configured metrics and events keep being tracked, so
+  collection resumes immediately. Useful when repurposing a device whose
+  historical data is no longer meaningful, or while debugging and
+  developing.
 * DDSketch-backed histograms on `summary`-type metrics. Opt in per
   metric via `reporter_options: [histogram: [...]]` to get percentiles
   (P50/P95/P99), SLO-style "% under threshold" counts, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ any time. The public API SHOULD NOT be considered stable.
 
 ### Added
 
+* `Mobius.reset/0` and `Mobius.reset/1` to clear everything out and return
+  Mobius to a clean state without a restart: the in-memory metrics table,
+  the accumulated history (RRD), the event log, and the persisted files on
+  disk (`history`, `metrics_table`, and `event_log`). Configured metrics
+  and events keep being tracked, so collection resumes immediately. Useful
+  when repurposing a device whose historical data is no longer meaningful,
+  or while debugging and developing.
 * DDSketch-backed histograms on `summary`-type metrics. Opt in per
   metric via `reporter_options: [histogram: [...]]` to get percentiles
   (P50/P95/P99), SLO-style "% under threshold" counts, and

--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -279,6 +279,38 @@ defmodule Mobius do
   end
 
   @doc """
+  Reset Mobius back to a clean state
+
+  This clears everything out for the instance without requiring a restart:
+
+  * the in-memory metrics table (current counters, sums, last values, and
+    summary/histogram data)
+  * the accumulated historical records (the in-memory RRD)
+  * the in-memory event log
+  * the persisted files on disk (`history`, `metrics_table`, and
+    `event_log`)
+
+  This is useful when repurposing a device whose historical data is no
+  longer meaningful, or while debugging and developing. The configured
+  metrics and events keep being tracked — only the recorded data is
+  discarded — so Mobius starts collecting fresh data immediately.
+
+  If you configured Mobius to use a different name then you can pass in your
+  custom name to ensure the right instance is reset.
+  """
+  @spec reset() :: :ok
+  def reset(), do: reset(@default_args[:mobius_instance])
+
+  @spec reset(instance()) :: :ok
+  def reset(instance) do
+    :ok = Scraper.reset(instance)
+    :ok = MetricsTable.Monitor.reset(instance)
+    :ok = EventLog.clear(instance: instance)
+
+    :ok
+  end
+
+  @doc """
   Get the latest metrics
 
   The latest metrics are the metrics recorded between the last query for the

--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -279,7 +279,7 @@ defmodule Mobius do
   end
 
   @doc """
-  Reset Mobius back to a clean state
+  Remove all data, returning Mobius to a clean state
 
   This clears everything out for the instance without requiring a restart:
 
@@ -296,15 +296,15 @@ defmodule Mobius do
   discarded — so Mobius starts collecting fresh data immediately.
 
   If you configured Mobius to use a different name then you can pass in your
-  custom name to ensure the right instance is reset.
+  custom name to ensure the data is removed from the right instance.
   """
-  @spec reset() :: :ok
-  def reset(), do: reset(@default_args[:mobius_instance])
+  @spec remove_all_data() :: :ok
+  def remove_all_data(), do: remove_all_data(@default_args[:mobius_instance])
 
-  @spec reset(instance()) :: :ok
-  def reset(instance) do
-    :ok = Scraper.reset(instance)
-    :ok = MetricsTable.Monitor.reset(instance)
+  @spec remove_all_data(instance()) :: :ok
+  def remove_all_data(instance) do
+    :ok = Scraper.remove_all_data(instance)
+    :ok = MetricsTable.Monitor.remove_all_data(instance)
     :ok = EventLog.clear(instance: instance)
 
     :ok

--- a/lib/mobius/event_log.ex
+++ b/lib/mobius/event_log.ex
@@ -53,6 +53,18 @@ defmodule Mobius.EventLog do
   end
 
   @doc """
+  Clear the event log
+
+  Empties the in-memory event log and removes the persisted event log file
+  for the instance.
+  """
+  @spec clear([opt()]) :: :ok
+  def clear(opts \\ []) do
+    instance = opts[:instance] || :mobius
+    EventsServer.clear(instance)
+  end
+
+  @doc """
   Parse the Mobius binary formatted event log
   """
   @spec parse(binary()) :: {:ok, [Event.t()]} | {:error, atom()}

--- a/lib/mobius/events_server.ex
+++ b/lib/mobius/events_server.ex
@@ -48,10 +48,14 @@ defmodule Mobius.EventsServer do
 
   @doc """
   Clear the event log and stored data
+
+  Empties the in-memory buffers and removes the persisted event log file.
+  Synchronous so callers only see `:ok` once the event log has actually
+  been cleared on disk.
   """
   @spec clear(Mobius.instance()) :: :ok
   def clear(instance \\ :mobius) do
-    GenServer.cast(name(instance), :reset)
+    GenServer.call(name(instance), :reset)
   end
 
   @impl GenServer
@@ -112,6 +116,20 @@ defmodule Mobius.EventsServer do
     {:reply, :ok, state}
   end
 
+  def handle_call(:reset, _from, state) do
+    path = make_file_path(state.persistence_dir)
+    _ = File.rm(path)
+    _ = File.rm(path <> ".tmp")
+
+    # Empty both buffers, keeping the out-of-time buffer present only when
+    # the clock is still unsynchronized (mirrors how init/1 sets it up).
+    out_of_time_buffer =
+      if state.out_of_time_buffer, do: CircularBuffer.new(100), else: nil
+
+    {:reply, :ok,
+     %{state | buffer: CircularBuffer.new(state.size), out_of_time_buffer: out_of_time_buffer}}
+  end
+
   @impl GenServer
   def handle_cast({:insert_event, event}, state) do
     if TimeServer.synchronized?(state.instance) do
@@ -122,14 +140,6 @@ defmodule Mobius.EventsServer do
       out_of_time_buffer = CircularBuffer.insert(state.out_of_time_buffer, event)
       {:noreply, %{state | out_of_time_buffer: out_of_time_buffer}}
     end
-  end
-
-  def handle_cast(:reset, state) do
-    path = make_file_path(state.persistence_dir)
-
-    _ = File.rm(path)
-
-    {:noreply, %{state | buffer: CircularBuffer.new(state.size)}}
   end
 
   @impl GenServer

--- a/lib/mobius/metrics_table.ex
+++ b/lib/mobius/metrics_table.ex
@@ -127,6 +127,34 @@ defmodule Mobius.MetricsTable do
   end
 
   @doc """
+  Clear all metrics and remove the persisted table file
+
+  Every recorded metric row is deleted, returning the table to the empty
+  state it had at boot. The resolved histogram configuration meta row is
+  preserved so newly recorded histograms keep using the configuration the
+  instance was started with. The persisted `metrics_table` file is removed
+  so a later save (or the save on shutdown) does not resurrect the cleared
+  data.
+  """
+  @spec reset(Mobius.instance(), Path.t()) :: :ok
+  def reset(instance, persistence_dir) do
+    configs =
+      case :ets.lookup(instance, @histogram_configs_key) do
+        [{@histogram_configs_key, configs}] -> configs
+        [] -> %{}
+      end
+
+    :ets.delete_all_objects(instance)
+    :ets.insert(instance, {@histogram_configs_key, configs})
+
+    path = Path.join(persistence_dir, "metrics_table")
+    _ = File.rm(path)
+    _ = File.rm(path <> ".tmp")
+
+    :ok
+  end
+
+  @doc """
   Put the metric information into the metric table
   """
   @spec put(

--- a/lib/mobius/metrics_table.ex
+++ b/lib/mobius/metrics_table.ex
@@ -136,8 +136,8 @@ defmodule Mobius.MetricsTable do
   so a later save (or the save on shutdown) does not resurrect the cleared
   data.
   """
-  @spec reset(Mobius.instance(), Path.t()) :: :ok
-  def reset(instance, persistence_dir) do
+  @spec remove_all_data(Mobius.instance(), Path.t()) :: :ok
+  def remove_all_data(instance, persistence_dir) do
     configs =
       case :ets.lookup(instance, @histogram_configs_key) do
         [{@histogram_configs_key, configs}] -> configs

--- a/lib/mobius/metrics_table/monitor.ex
+++ b/lib/mobius/metrics_table/monitor.ex
@@ -27,8 +27,8 @@ defmodule Mobius.MetricsTable.Monitor do
   @doc """
   Clear all metrics and remove the persisted metrics table file
   """
-  @spec reset(Mobius.instance()) :: :ok
-  def reset(instance), do: GenServer.call(name(instance), :reset)
+  @spec remove_all_data(Mobius.instance()) :: :ok
+  def remove_all_data(instance), do: GenServer.call(name(instance), :remove_all_data)
 
   @impl GenServer
   def init(args) do
@@ -47,8 +47,8 @@ defmodule Mobius.MetricsTable.Monitor do
     {:reply, save_to_persistence(state), state}
   end
 
-  def handle_call(:reset, _from, state) do
-    {:reply, MetricsTable.reset(state.mobius_instance, state.persistence_dir), state}
+  def handle_call(:remove_all_data, _from, state) do
+    {:reply, MetricsTable.remove_all_data(state.mobius_instance, state.persistence_dir), state}
   end
 
   @impl GenServer

--- a/lib/mobius/metrics_table/monitor.ex
+++ b/lib/mobius/metrics_table/monitor.ex
@@ -24,6 +24,12 @@ defmodule Mobius.MetricsTable.Monitor do
   @spec save(Mobius.instance()) :: :ok | {:error, reason :: term()}
   def save(instance), do: GenServer.call(name(instance), :save)
 
+  @doc """
+  Clear all metrics and remove the persisted metrics table file
+  """
+  @spec reset(Mobius.instance()) :: :ok
+  def reset(instance), do: GenServer.call(name(instance), :reset)
+
   @impl GenServer
   def init(args) do
     Process.flag(:trap_exit, true)
@@ -39,6 +45,10 @@ defmodule Mobius.MetricsTable.Monitor do
   @impl GenServer
   def handle_call(:save, _from, state) do
     {:reply, save_to_persistence(state), state}
+  end
+
+  def handle_call(:reset, _from, state) do
+    {:reply, MetricsTable.reset(state.mobius_instance, state.persistence_dir), state}
   end
 
   @impl GenServer

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -47,6 +47,12 @@ defmodule Mobius.Scraper do
   @spec save(Mobius.instance()) :: :ok | {:error, reason :: term()}
   def save(instance), do: GenServer.call(name(instance), :save)
 
+  @doc """
+  Clear all in-memory history and remove the persisted history file
+  """
+  @spec reset(Mobius.instance()) :: :ok
+  def reset(instance), do: GenServer.call(name(instance), :reset)
+
   @impl GenServer
   def init(args) do
     _ = :timer.send_interval(@interval, self(), :scrape)
@@ -71,11 +77,14 @@ defmodule Mobius.Scraper do
   end
 
   defp make_database(state, args) do
-    rrd =
-      args[:database]
-      |> load_data(state)
+    # Keep the pristine, empty database around so reset/1 can discard all
+    # stored data while preserving the configured resolution capacities.
+    empty = args[:database]
+    rrd = load_data(empty, state)
 
-    Map.put(state, :database, rrd)
+    state
+    |> Map.put(:database, rrd)
+    |> Map.put(:empty_database, empty)
   end
 
   defp load_data(database, state) do
@@ -181,6 +190,15 @@ defmodule Mobius.Scraper do
 
   def handle_call(:save, _from, state) do
     {:reply, save_to_persistence(state), state}
+  end
+
+  def handle_call(:reset, _from, state) do
+    # Drop the persisted history file so a later save (or the terminate
+    # save on shutdown) does not resurrect the data we just cleared.
+    _ = File.rm(file(state))
+    _ = File.rm(file(state) <> ".tmp")
+
+    {:reply, :ok, %{state | database: state.empty_database}}
   end
 
   defp query_snapshots(state, opts) do

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -50,8 +50,8 @@ defmodule Mobius.Scraper do
   @doc """
   Clear all in-memory history and remove the persisted history file
   """
-  @spec reset(Mobius.instance()) :: :ok
-  def reset(instance), do: GenServer.call(name(instance), :reset)
+  @spec remove_all_data(Mobius.instance()) :: :ok
+  def remove_all_data(instance), do: GenServer.call(name(instance), :remove_all_data)
 
   @impl GenServer
   def init(args) do
@@ -77,8 +77,9 @@ defmodule Mobius.Scraper do
   end
 
   defp make_database(state, args) do
-    # Keep the pristine, empty database around so reset/1 can discard all
-    # stored data while preserving the configured resolution capacities.
+    # Keep the pristine, empty database around so remove_all_data/1 can
+    # discard all stored data while preserving the configured resolution
+    # capacities.
     empty = args[:database]
     rrd = load_data(empty, state)
 
@@ -192,7 +193,7 @@ defmodule Mobius.Scraper do
     {:reply, save_to_persistence(state), state}
   end
 
-  def handle_call(:reset, _from, state) do
+  def handle_call(:remove_all_data, _from, state) do
     # Drop the persisted history file so a later save (or the terminate
     # save on shutdown) does not resurrect the data we just cleared.
     _ = File.rm(file(state))

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -128,6 +128,102 @@ defmodule MobiusTest do
     assert File.exists?(Path.join(persistence_path, "metrics_table"))
   end
 
+  describe "reset/1" do
+    test "clears in-memory metrics, history, the event log, and persisted files" do
+      persistence_path = Path.join(@persistence_dir, @default_instance_str)
+      instance = String.to_atom(@default_instance_str)
+
+      metrics = [
+        Telemetry.Metrics.counter("reset.test.count", event_name: [:reset, :test])
+      ]
+
+      {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
+
+      # Record a metric and an event.
+      :telemetry.execute([:reset, :test], %{count: 1}, %{})
+
+      Mobius.EventsServer.insert(
+        instance,
+        Mobius.Event.new("test", "reset.event", %{a: 1}, %{}, timestamp: 1)
+      )
+
+      # In-memory metrics table now has an entry.
+      assert Mobius.MetricsTable.get_entries(instance) != []
+
+      # Give the scraper a tick to capture a snapshot into the RRD.
+      Process.sleep(1_100)
+      refute Enum.empty?(Mobius.Scraper.all(instance))
+
+      # The event landed in the event log.
+      assert Mobius.EventLog.list(instance: instance) != []
+
+      # Persist everything to disk.
+      assert :ok = Mobius.save(instance)
+      assert File.exists?(Path.join(persistence_path, "history"))
+      assert File.exists?(Path.join(persistence_path, "metrics_table"))
+      assert File.exists?(Path.join(persistence_path, "event_log"))
+
+      # Reset wipes it all out.
+      assert :ok = Mobius.reset(instance)
+
+      assert Mobius.MetricsTable.get_entries(instance) == []
+      assert Mobius.Scraper.all(instance) == []
+      assert Mobius.EventLog.list(instance: instance) == []
+
+      refute File.exists?(Path.join(persistence_path, "history"))
+      refute File.exists?(Path.join(persistence_path, "metrics_table"))
+      refute File.exists?(Path.join(persistence_path, "event_log"))
+    end
+
+    test "keeps tracking configured metrics after a reset" do
+      instance = String.to_atom(@default_instance_str)
+
+      metrics = [
+        Telemetry.Metrics.counter("reset.again.count", event_name: [:reset, :again])
+      ]
+
+      {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
+
+      :telemetry.execute([:reset, :again], %{count: 1}, %{})
+      assert Mobius.MetricsTable.get_entries(instance) != []
+
+      assert :ok = Mobius.reset(instance)
+      assert Mobius.MetricsTable.get_entries(instance) == []
+
+      # The metric is still registered, so new measurements are recorded.
+      :telemetry.execute([:reset, :again], %{count: 1}, %{})
+      assert Mobius.MetricsTable.get_entries(instance) != []
+    end
+
+    test "a later save does not resurrect cleared data" do
+      instance = String.to_atom(@default_instance_str)
+
+      metrics = [
+        Telemetry.Metrics.counter("reset.save.count", event_name: [:reset, :save])
+      ]
+
+      {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
+
+      :telemetry.execute([:reset, :save], %{count: 1}, %{})
+      Process.sleep(1_100)
+
+      assert :ok = Mobius.reset(instance)
+      assert :ok = Mobius.save(instance)
+
+      # The metrics table file may be written again, but it must hold no
+      # recorded metrics, and the history must stay empty.
+      assert Mobius.MetricsTable.get_entries(instance) == []
+      assert Mobius.Scraper.all(instance) == []
+
+      stop_supervised!(Mobius)
+
+      {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
+
+      assert Mobius.MetricsTable.get_entries(instance) == []
+      assert Mobius.Scraper.all(instance) == []
+    end
+  end
+
   defp file(persistence_dir) do
     Path.join(persistence_dir, "history")
   end

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -128,23 +128,25 @@ defmodule MobiusTest do
     assert File.exists?(Path.join(persistence_path, "metrics_table"))
   end
 
-  describe "reset/1" do
+  describe "remove_all_data/1" do
     test "clears in-memory metrics, history, the event log, and persisted files" do
       persistence_path = Path.join(@persistence_dir, @default_instance_str)
       instance = String.to_atom(@default_instance_str)
 
       metrics = [
-        Telemetry.Metrics.counter("reset.test.count", event_name: [:reset, :test])
+        Telemetry.Metrics.counter("remove_all_data.test.count",
+          event_name: [:remove_all_data, :test]
+        )
       ]
 
       {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
 
       # Record a metric and an event.
-      :telemetry.execute([:reset, :test], %{count: 1}, %{})
+      :telemetry.execute([:remove_all_data, :test], %{count: 1}, %{})
 
       Mobius.EventsServer.insert(
         instance,
-        Mobius.Event.new("test", "reset.event", %{a: 1}, %{}, timestamp: 1)
+        Mobius.Event.new("test", "remove_all_data.event", %{a: 1}, %{}, timestamp: 1)
       )
 
       # In-memory metrics table now has an entry.
@@ -163,8 +165,8 @@ defmodule MobiusTest do
       assert File.exists?(Path.join(persistence_path, "metrics_table"))
       assert File.exists?(Path.join(persistence_path, "event_log"))
 
-      # Reset wipes it all out.
-      assert :ok = Mobius.reset(instance)
+      # Removing all data wipes it all out.
+      assert :ok = Mobius.remove_all_data(instance)
 
       assert Mobius.MetricsTable.get_entries(instance) == []
       assert Mobius.Scraper.all(instance) == []
@@ -175,23 +177,25 @@ defmodule MobiusTest do
       refute File.exists?(Path.join(persistence_path, "event_log"))
     end
 
-    test "keeps tracking configured metrics after a reset" do
+    test "keeps tracking configured metrics after removing all data" do
       instance = String.to_atom(@default_instance_str)
 
       metrics = [
-        Telemetry.Metrics.counter("reset.again.count", event_name: [:reset, :again])
+        Telemetry.Metrics.counter("remove_all_data.again.count",
+          event_name: [:remove_all_data, :again]
+        )
       ]
 
       {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
 
-      :telemetry.execute([:reset, :again], %{count: 1}, %{})
+      :telemetry.execute([:remove_all_data, :again], %{count: 1}, %{})
       assert Mobius.MetricsTable.get_entries(instance) != []
 
-      assert :ok = Mobius.reset(instance)
+      assert :ok = Mobius.remove_all_data(instance)
       assert Mobius.MetricsTable.get_entries(instance) == []
 
       # The metric is still registered, so new measurements are recorded.
-      :telemetry.execute([:reset, :again], %{count: 1}, %{})
+      :telemetry.execute([:remove_all_data, :again], %{count: 1}, %{})
       assert Mobius.MetricsTable.get_entries(instance) != []
     end
 
@@ -199,15 +203,17 @@ defmodule MobiusTest do
       instance = String.to_atom(@default_instance_str)
 
       metrics = [
-        Telemetry.Metrics.counter("reset.save.count", event_name: [:reset, :save])
+        Telemetry.Metrics.counter("remove_all_data.save.count",
+          event_name: [:remove_all_data, :save]
+        )
       ]
 
       {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
 
-      :telemetry.execute([:reset, :save], %{count: 1}, %{})
+      :telemetry.execute([:remove_all_data, :save], %{count: 1}, %{})
       Process.sleep(1_100)
 
-      assert :ok = Mobius.reset(instance)
+      assert :ok = Mobius.remove_all_data(instance)
       assert :ok = Mobius.save(instance)
 
       # The metrics table file may be written again, but it must hold no


### PR DESCRIPTION
Resolves #13.

## What

Adds a public `Mobius.remove_all_data/0` and `Mobius.remove_all_data/1` that returns a Mobius instance to a clean state without requiring a restart. This is for the two use cases in the issue: repurposing a Nerves device whose historical data is no longer meaningful, and debugging/development.

`remove_all_data/0` clears the default `:mobius` instance; `remove_all_data/1` takes an instance name, matching the existing convention of the other public functions in `lib/mobius.ex`.

## What gets cleared

Everything that constitutes Mobius state:

- **In-memory metrics** — the metrics ETS table is emptied (`Mobius.MetricsTable.remove_all_data/2`), driven through `Mobius.MetricsTable.Monitor` which holds the resolved per-instance persistence dir. The resolved histogram-configuration meta row is preserved so newly recorded histograms keep using the configuration the instance was started with.
- **Accumulated history** — the in-memory RRD held in `Mobius.Scraper`. The scraper now keeps the pristine empty database around so the data can be discarded while preserving the configured resolution capacities.
- **Event log** — the in-memory buffers in `Mobius.EventsServer`. The previously-unused clear path is now synchronous (so callers only see `:ok` once the log is actually cleared) and also resets the out-of-time buffer. Exposed publicly as `Mobius.EventLog.clear/1`.
- **Persisted files on disk** — `history`, `metrics_table`, and `event_log` (plus any leftover `.tmp` files), so a later save or the save-on-shutdown cannot resurrect the data that was just cleared.

Configured metrics and events keep being tracked, so collection resumes immediately after the data is removed.

## Tests

Added a `remove_all_data/1` describe block in `test/mobius_test.exs` covering:
- recording metrics + history + an event, saving, then asserting in-memory state and all three persisted files are gone after removing all data
- metrics still being tracked (and recorded) after removing all data
- a later save not resurrecting cleared data, verified across a supervisor restart

## Checks run locally

`mix test` (164 tests, 0 failures), `mix format --check-formatted`, `mix compile --warnings-as-errors --force`, `mix credo -a --strict`, `mix dialyzer`, `mix deps.unlock --check-unused` all pass.

Also added a CHANGELOG.md entry under Unreleased / Added.
