### PR TITLE
Fix Mobius.info crash on histogram-enabled metrics

### DIFF
--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -241,6 +241,7 @@ defmodule Mobius do
   def info(instance) do
     instance
     |> MetricsTable.get_entries()
+    |> Enum.reject(fn {_metric_name, type, _value, _meta} -> histogram_bin?(type) end)
     |> Enum.group_by(fn {metric_name, _type, _value, meta} -> {metric_name, meta} end)
     |> Enum.each(fn {{metric_name, meta}, metrics} ->
       reports =
@@ -258,6 +259,11 @@ defmodule Mobius do
       |> IO.puts()
     end)
   end
+
+  # Histogram bin rows carry tuple types such as `{:hist, :pos, idx}` and
+  # `{:hist, :zero}`. They back the sketch for the metric's summary and are
+  # not meaningful as individual lines, so they are left out of the listing.
+  defp histogram_bin?(type), do: is_tuple(type) and elem(type, 0) == :hist
 
   defp format_value(:summary, summary_data) do
     Summary.calculate(summary_data)

--- a/test/mobius/info_test.exs
+++ b/test/mobius/info_test.exs
@@ -1,0 +1,55 @@
+defmodule Mobius.InfoTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureIO
+
+  @persistence_dir System.tmp_dir!() |> Path.join("mobius_info_test")
+  @instance :mobius
+
+  setup do
+    File.rm_rf!(@persistence_dir)
+    File.mkdir_p(@persistence_dir)
+
+    :ok
+  end
+
+  test "prints metrics for a plain counter" do
+    metrics = [
+      Telemetry.Metrics.counter("info.plain.count", event_name: [:info, :plain])
+    ]
+
+    {:ok, _pid} =
+      start_supervised({Mobius, persistence_dir: @persistence_dir, metrics: metrics})
+
+    :telemetry.execute([:info, :plain], %{count: 1}, %{})
+
+    output = capture_io(fn -> assert :ok = Mobius.info(@instance) end)
+
+    assert output =~ "Metric Name: info.plain.count"
+    assert output =~ "counter: 1"
+  end
+
+  test "does not crash when a histogram-enabled metric has data" do
+    metrics = [
+      Telemetry.Metrics.summary("info.hist.duration",
+        event_name: [:info, :hist],
+        measurement: :duration,
+        reporter_options: [histogram: true]
+      )
+    ]
+
+    {:ok, _pid} =
+      start_supervised({Mobius, persistence_dir: @persistence_dir, metrics: metrics})
+
+    :telemetry.execute([:info, :hist], %{duration: 12.5}, %{})
+
+    # The recorded value produced histogram bin rows with tuple types
+    entries = Mobius.MetricsTable.get_entries_by_metric_name(@instance, "info.hist.duration")
+    assert Enum.any?(entries, fn {_, type, _, _} -> match?({:hist, _, _}, type) end)
+
+    output = capture_io(fn -> assert :ok = Mobius.info(@instance) end)
+
+    assert output =~ "Metric Name: info.hist.duration"
+    assert output =~ "summary:"
+    refute output =~ "{:hist"
+  end
+end


### PR DESCRIPTION
Closes #115

`Mobius.info/1` formats each metrics-table row with `to_string(type)`, but histogram bin rows carry tuple types (`{:hist, :pos, idx}`, `{:hist, :zero}`), so any histogram-enabled metric with recorded data crashes the listing with `Protocol.UndefinedError`.

The first commit is a deliberately failing test confirming the issue; the second commit filters the histogram bin rows out of the info listing. Normal metric output is unchanged.

CI note: all CircleCI jobs pass except `1.20.0-erlang-29.0.1`, which fails `mix credo -a --strict` with three pre-existing `String.to_atom` warnings in `test/mobius_test.exs` (lines 135, 182, 204). That job fails identically on main's tip (ba976ab, which enabled `Credo.Check.Warning.UnsafeToAtom`) — the failure is inherited from main, not introduced here. This PR adds no new credo findings; `mix format --check-formatted` and `mix test` (188 tests, 1 doctest) pass locally.