### PR TITLE
Fix clock-sync adjustment to use only the clock step

### DIFF
--- a/lib/mobius/time_server.ex
+++ b/lib/mobius/time_server.ex
@@ -81,7 +81,8 @@ defmodule Mobius.TimeServer do
   def handle_info(:check_clock, %{synced?: false} = state) do
     if state.clock.synchronized?() do
       sync_timestamp = System.system_time()
-      adjustment = sync_timestamp - state.started_sys_time
+      elapsed = System.monotonic_time() - state.started_at
+      adjustment = sync_timestamp - (state.started_sys_time + elapsed)
 
       :ok = notify(sync_timestamp, adjustment, state.registered)
 

--- a/test/mobius/time_server_test.exs
+++ b/test/mobius/time_server_test.exs
@@ -7,7 +7,7 @@ defmodule Mobius.TimeServerTest do
     @behaviour Mobius.Clock
 
     @impl Mobius.Clock
-    def synchronized? do
+    def synchronized?() do
       :persistent_term.get({__MODULE__, :synchronized?}, false)
     end
 

--- a/test/mobius/time_server_test.exs
+++ b/test/mobius/time_server_test.exs
@@ -1,0 +1,39 @@
+defmodule Mobius.TimeServerTest do
+  use ExUnit.Case, async: false
+
+  alias Mobius.TimeServer
+
+  defmodule TestClock do
+    @behaviour Mobius.Clock
+
+    @impl Mobius.Clock
+    def synchronized? do
+      :persistent_term.get({__MODULE__, :synchronized?}, false)
+    end
+
+    def set_synchronized(value) do
+      :persistent_term.put({__MODULE__, :synchronized?}, value)
+    end
+  end
+
+  test "adjustment reflects only the clock step, not the time spent waiting for sync" do
+    TestClock.set_synchronized(false)
+    on_exit(fn -> :persistent_term.erase({TestClock, :synchronized?}) end)
+
+    start_supervised!(
+      {TimeServer, [mobius_instance: :time_server_test, clock: TestClock, session: "test"]}
+    )
+
+    :ok = TimeServer.register(:time_server_test, self())
+
+    # Let real time pass between boot and sync detection. The wall clock
+    # never steps in this test, so the true adjustment is ~0.
+    Process.sleep(1_500)
+    TestClock.set_synchronized(true)
+
+    assert_receive {Mobius.TimeServer, _sync_timestamp, adjustment}, 5_000
+
+    adjustment_ms = System.convert_time_unit(adjustment, :native, :millisecond)
+    assert abs(adjustment_ms) < 500
+  end
+end


### PR DESCRIPTION
Closes #119

The first commit is a deliberately failing test confirming the issue: `TimeServer` computes the adjustment as `sync_system_time - started_sys_time`, which folds in the real time elapsed between boot and sync detection. In the test the wall clock never steps, so the true adjustment is ~0, yet the current code reports roughly the time spent waiting for sync (~2 s).

The second commit fixes `TimeServer` to compute the adjustment as the clock step only, using the monotonic `started_at` captured in `init/1` (previously unused): `sync_system_time - (started_sys_time + elapsed_monotonic)`.

Locally verified: `mix format --check-formatted`, `mix credo --strict`, and `mix test` all pass.