### PR TITLE
Honor documented event options :measurement_values and :group

### DIFF
--- a/lib/mobius/event_log.ex
+++ b/lib/mobius/event_log.ex
@@ -10,8 +10,17 @@ defmodule Mobius.EventLog do
 
   @typedoc """
   Options to query the event log
+
+  * `:from` - the unix timestamp (in seconds) to start listing events from
+  * `:to` - the unix timestamp (in seconds) to list events until
+  * `:instance` - the Mobius instance to query (defaults to `:mobius`)
+  * `:group` - only list events that belong to this event group
   """
-  @type opt() :: {:from, integer()} | {:to, integer()} | {:instance, Mobius.instance()}
+  @type opt() ::
+          {:from, integer()}
+          | {:to, integer()}
+          | {:instance, Mobius.instance()}
+          | {:group, atom()}
 
   @doc """
   List the events in the event log

--- a/lib/mobius/events.ex
+++ b/lib/mobius/events.ex
@@ -311,14 +311,17 @@ defmodule Mobius.Events do
     measurements = process_measurements(measurements, opts)
     tags = get_event_tags(metadata, opts)
 
-    event = Mobius.Event.new(session, event, measurements, tags)
+    event = Mobius.Event.new(session, event, measurements, tags, Keyword.take(opts, [:group]))
 
     Mobius.EventsServer.insert(instance, event)
     :ok
   end
 
   defp process_measurements(measurements, opts) do
-    case opts[:measurements_values] do
+    # :measurements_values is a historical misspelling of the documented
+    # :measurement_values option, kept for backward compatibility. The
+    # documented key wins when both are given.
+    case opts[:measurement_values] || opts[:measurements_values] do
       nil ->
         measurements
 

--- a/lib/mobius/events_server.ex
+++ b/lib/mobius/events_server.ex
@@ -192,12 +192,14 @@ defmodule Mobius.EventsServer do
   defp make_list(buffer, opts) do
     from = opts[:from] || 0
     to = opts[:to] || System.system_time(:second)
+    group = opts[:group]
 
     buffer
     |> CircularBuffer.to_list()
     |> Enum.sort_by(fn event -> event.timestamp end)
     |> Enum.filter(fn event ->
-      event.timestamp >= from && event.timestamp <= to
+      event.timestamp >= from && event.timestamp <= to &&
+        (group == nil || event.group == group)
     end)
   end
 

--- a/test/mobius/event_log_test.exs
+++ b/test/mobius/event_log_test.exs
@@ -141,6 +141,21 @@ defmodule Mobius.EventLogTest do
     end
 
     @tag :tmp_dir
+    test "filter by group", %{tmp_dir: tmp_dir} do
+      events = [
+        Event.new("test", "a.b.c", %{a: 1}, %{}, group: :network, timestamp: 1),
+        Event.new("test", "d.e.f", %{a: 1}, %{}, timestamp: 2),
+        Event.new("test", "g.h.i", %{a: 1}, %{}, group: :network, timestamp: 3)
+      ]
+
+      load_event_log(:filter_event_group, tmp_dir, events)
+
+      logged_events = EventLog.list(instance: :filter_event_group, group: :network)
+
+      assert logged_events == [List.first(events), List.last(events)]
+    end
+
+    @tag :tmp_dir
     test "provide complete time window", %{tmp_dir: tmp_dir} do
       events = [
         Event.new("test", "a.b.c", %{a: 1}, %{}, timestamp: 1),

--- a/test/mobius/events_test.exs
+++ b/test/mobius/events_test.exs
@@ -72,7 +72,7 @@ defmodule Mobius.EventsTest do
     end
 
     @tag :tmp_dir
-    test "process measurements", %{tmp_dir: tmp_dir} do
+    test "process measurements with legacy :measurements_values key", %{tmp_dir: tmp_dir} do
       start_supervised!(
         {Mobius, mobius_instance: :process_measurements, persistence_dir: tmp_dir}
       )

--- a/test/mobius/events_test.exs
+++ b/test/mobius/events_test.exs
@@ -91,6 +91,43 @@ defmodule Mobius.EventsTest do
       assert event.measurements == %{a: 2, b: 1}
       assert event.tags == %{t: 1}
     end
+
+    @tag :tmp_dir
+    test "process measurements with documented :measurement_values key", %{tmp_dir: tmp_dir} do
+      start_supervised!({Mobius, mobius_instance: :measurement_values, persistence_dir: tmp_dir})
+
+      config = %{
+        table: :measurement_values,
+        event_opts: [tags: [:t], measurement_values: &event_measurement_processor/1],
+        session: "test"
+      }
+
+      :ok = Events.handle_event("a.b.c", %{a: 1, b: 1}, %{t: 1, z: 2}, config)
+
+      assert [event] = Mobius.EventLog.list(instance: :measurement_values)
+
+      assert event.name == "a.b.c"
+      assert event.measurements == %{a: 2, b: 1}
+      assert event.tags == %{t: 1}
+    end
+
+    @tag :tmp_dir
+    test "applies the :group option", %{tmp_dir: tmp_dir} do
+      start_supervised!({Mobius, mobius_instance: :event_group, persistence_dir: tmp_dir})
+
+      config = %{
+        table: :event_group,
+        event_opts: [group: :network],
+        session: "test"
+      }
+
+      :ok = Events.handle_event("a.b.c", %{a: 1}, %{}, config)
+
+      assert [event] = Mobius.EventLog.list(instance: :event_group)
+
+      assert event.name == "a.b.c"
+      assert event.group == :network
+    end
   end
 
   defp event_measurement_processor({:a, n}) do


### PR DESCRIPTION
Closes #117

The first commit deliberately adds failing tests confirming the issue: events configured with the documented `:measurement_values` key get no measurement processing (the implementation reads the misspelled `:measurements_values`), and the documented `:group` option is never applied (`Events.process_event/6` calls `Event.new/4` without the event opts, so every event gets `group: :default`).

The follow-up commit fixes both: the documented key is read (the legacy misspelling is still accepted for backward compatibility, with the documented key winning), event opts are passed through so `:group` is honored, and `Mobius.EventLog.list/1` gains a `:group` filter option so groups are actually usable.

Note: this repository has no CI workflows, so no checks will run on this PR. `mix format --check-formatted`, `mix credo --strict`, and `mix test` were run locally as the effective gate.