### PR TITLE
Fix stale-metric pruning in Mobius.Registry

### DIFF
--- a/lib/mobius/registry.ex
+++ b/lib/mobius/registry.ex
@@ -112,22 +112,28 @@ defmodule Mobius.Registry do
 
   @impl GenServer
   def handle_continue(:update_metrics_table, state) do
+    metric_specs =
+      Enum.map(state.metrics, &{&1.name, metric_as_type(&1), Enum.sort(&1.tags)})
+
     state.table
     |> MetricsTable.get_entries()
-    |> Enum.each(&maybe_remove_entry(&1, state))
+    |> Enum.each(&maybe_remove_entry(&1, metric_specs, state.table))
 
     {:noreply, state}
   end
 
-  defp maybe_remove_entry({_name, {:hist, _region, _idx}, _value, _meta}, _state), do: :ok
-  defp maybe_remove_entry({_name, {:hist, :zero}, _value, _meta}, _state), do: :ok
+  defp maybe_remove_entry({_name, {:hist, _region, _idx}, _value, _meta}, _specs, _table), do: :ok
+  defp maybe_remove_entry({_name, {:hist, :zero}, _value, _meta}, _specs, _table), do: :ok
 
-  defp maybe_remove_entry({metric_name, metric_type, _value, meta}, state) do
-    metric_specs = Enum.map(state.metrics, &{&1.name, metric_as_type(&1), &1.tags})
-    entry_spec = {metric_name, metric_type, Map.keys(meta)}
+  defp maybe_remove_entry({metric_name, metric_type, _value, meta}, metric_specs, table) do
+    # Entries from the table carry string names while the table itself (and
+    # the configured metrics) use atom lists, so parse the name back before
+    # comparing and removing.
+    name = parse_event_name(metric_name)
+    entry_spec = {name, metric_type, meta |> Map.keys() |> Enum.sort()}
 
     if !Enum.member?(metric_specs, entry_spec) do
-      MetricsTable.remove(state.table, metric_name, metric_type, meta)
+      MetricsTable.remove(table, name, metric_type, meta)
     end
   end
 

--- a/test/mobius/registry_test.exs
+++ b/test/mobius/registry_test.exs
@@ -1,0 +1,59 @@
+defmodule Mobius.RegistryTest do
+  use ExUnit.Case, async: false
+
+  alias Mobius.{MetricsTable, Registry}
+  alias Telemetry.Metrics
+
+  test "removes restored entries for metrics that are no longer configured" do
+    table = :registry_stale_prune_test
+    MetricsTable.init(mobius_instance: table, persistence_dir: "/does/not/matter/here")
+
+    # Simulate entries restored from a persisted table: one for a metric that
+    # is still configured, one for a metric that no longer is, and a histogram
+    # bin row which the registry must never touch.
+    :ok = MetricsTable.put(table, [:vm, :memory, :total], :last_value, 100)
+    :ok = MetricsTable.put(table, [:old, :metric], :counter, 1)
+    :ok = MetricsTable.inc_histogram_bin(table, [:old, :metric], {:hist, :pos, 3})
+
+    metrics = [Metrics.last_value("vm.memory.total")]
+
+    start_supervised!({Registry, mobius_instance: table, metrics: metrics})
+
+    # Pruning runs in a handle_continue; a call ensures it has completed.
+    assert ^metrics = Registry.metrics(table)
+
+    entries = MetricsTable.get_entries(table)
+
+    # The entry for the still-configured metric is kept.
+    assert {"vm.memory.total", :last_value, 100, %{}} in entries
+
+    # The stale entry is removed.
+    refute {"old.metric", :counter, 1, %{}} in entries
+
+    # Histogram bin rows are not pruned by the registry.
+    assert {"old.metric", {:hist, :pos, 3}, 1, %{}} in entries
+  end
+
+  test "keeps restored entries for configured metrics with tags in declaration order" do
+    table = :registry_tagged_prune_test
+    MetricsTable.init(mobius_instance: table, persistence_dir: "/does/not/matter/here")
+
+    :ok =
+      MetricsTable.put(table, [:tagged, :metric, :count], :counter, 1, %{
+        zone: "a",
+        host: "h"
+      })
+
+    # Tags declared in non-sorted order: comparing them against the sorted
+    # keys of the entry metadata must not prune the entry.
+    metrics = [Metrics.counter("tagged.metric.count", tags: [:zone, :host])]
+
+    start_supervised!({Registry, mobius_instance: table, metrics: metrics})
+
+    assert ^metrics = Registry.metrics(table)
+
+    assert {"tagged.metric.count", :counter, 1, %{zone: "a", host: "h"}} in MetricsTable.get_entries(
+             table
+           )
+  end
+end


### PR DESCRIPTION
Closes #116

The first commit is a deliberately failing test confirming the issue: a metrics-table entry for a metric that is no longer configured (simulating an entry restored from a persisted table) survives registry startup because `maybe_remove_entry/2` compares string entry names against atom-list metric names (never equal) and then builds the ETS delete key from the string name (never matches), making the prune a silent no-op.

The second commit fixes `Mobius.Registry` to compare both sides in the table's native atom-list format, sort tag keys on both sides before comparing, build the spec list once, and pass the atom-list name to `MetricsTable.remove/4` so the delete actually hits. Histogram bin rows remain untouched by this code path.

Locally verified with `mix format --check-formatted`, `mix credo --strict`, and `mix test` (plus a warnings-as-errors compile on Elixir 1.20.0-rc.1).