### PR TITLE
Make RRD.save/2 refuse non-current serialization versions

### DIFF
--- a/lib/mobius/rrd.ex
+++ b/lib/mobius/rrd.ex
@@ -402,23 +402,11 @@ defmodule Mobius.RRD do
   @doc """
   Serialize to an iolist
 
-  Always writes the current serialization format. There is no
-  down-conversion to older formats: passing a `:serialization_version`
-  other than the current one raises `ArgumentError` rather than emitting
-  a file that `load/3` cannot read.
+  Always writes the current serialization format; `load/3` handles older
+  formats on the way back in.
   """
   @spec save(t(), [save_opt()]) :: iolist()
   def save(rrd, opts \\ []) do
-    case Keyword.get(opts, :serialization_version, @serialization_version) do
-      @serialization_version ->
-        :ok
-
-      other ->
-        raise ArgumentError,
-              "save/2 only writes serialization version #{@serialization_version}, " <>
-                "got: #{inspect(other)}"
-    end
-
     compression_level = opts[:compression_level] || @default_compression_level
     payload = %{configs: opts[:histogram_configs] || %{}, data: all(rrd)}
 

--- a/lib/mobius/rrd.ex
+++ b/lib/mobius/rrd.ex
@@ -389,8 +389,6 @@ defmodule Mobius.RRD do
   @typedoc """
   Options for saving RRD into a binary
 
-  * `:serialization_version` - the version of serialization format, defaults to
-    most recent
   * `:histogram_configs` - the resolved sketch configuration per
     histogram-enabled metric, recorded in v3 files so `load/3` can detect
     histogram data produced under a different configuration
@@ -398,26 +396,36 @@ defmodule Mobius.RRD do
     defaults to `9`. `0` disables compression.
   """
   @type save_opt() ::
-          {:serialization_version, 1 | 2 | 3}
-          | {:histogram_configs, %{histogram_config_key() => map()}}
+          {:histogram_configs, %{histogram_config_key() => map()}}
           | {:compression_level, 0..9}
 
   @doc """
   Serialize to an iolist
+
+  Always writes the current serialization format. There is no
+  down-conversion to older formats: passing a `:serialization_version`
+  other than the current one raises `ArgumentError` rather than emitting
+  a file that `load/3` cannot read.
   """
   @spec save(t(), [save_opt()]) :: iolist()
   def save(rrd, opts \\ []) do
-    serialization_version = opts[:serialization_version] || @serialization_version
+    case Keyword.get(opts, :serialization_version, @serialization_version) do
+      @serialization_version ->
+        :ok
+
+      other ->
+        raise ArgumentError,
+              "save/2 only writes serialization version #{@serialization_version}, " <>
+                "got: #{inspect(other)}"
+    end
+
     compression_level = opts[:compression_level] || @default_compression_level
+    payload = %{configs: opts[:histogram_configs] || %{}, data: all(rrd)}
 
-    payload =
-      if serialization_version >= 3 do
-        %{configs: opts[:histogram_configs] || %{}, data: all(rrd)}
-      else
-        all(rrd)
-      end
-
-    [serialization_version, :erlang.term_to_binary(payload, [{:compressed, compression_level}])]
+    [
+      @serialization_version,
+      :erlang.term_to_binary(payload, [{:compressed, compression_level}])
+    ]
   end
 
   @doc """

--- a/test/mobius/rrd_test.exs
+++ b/test/mobius/rrd_test.exs
@@ -37,36 +37,36 @@ defmodule Mobius.RRDTest do
 
   describe "serialize and decode" do
     test "version 1" do
-      in_rrd =
-        RRD.new(@args)
-        |> RRD.insert(1234, [{[:vm, :memory, :total], :last_value, 123, %{}}])
-        |> RRD.insert(3000, [{[:vm, :memory, :total], :last_value, 124, %{}}])
+      v1_data = [
+        {1234, [{[:vm, :memory, :total], :last_value, 123, %{}}]},
+        {3000, [{[:vm, :memory, :total], :last_value, 124, %{}}]}
+      ]
+
+      v1_binary = IO.iodata_to_binary([1, :erlang.term_to_binary(v1_data)])
 
       expected_rrd =
         RRD.new(@args)
         |> RRD.insert(1234, {[{"vm.memory.total", :last_value, 123, %{}}], %{}})
         |> RRD.insert(3000, {[{"vm.memory.total", :last_value, 124, %{}}], %{}})
 
-      in_rrd_binary = RRD.save(in_rrd, serialization_version: 1) |> IO.iodata_to_binary()
-      assert RRD.load(RRD.new(@args), in_rrd_binary) == {:ok, expected_rrd}
+      assert RRD.load(RRD.new(@args), v1_binary) == {:ok, expected_rrd}
     end
 
     test "version 2 (legacy map-shape records)" do
-      v2_in_rrd =
-        RRD.new(@args)
-        |> RRD.insert(1234, [
-          %{name: "vm.memory.total", type: :last_value, value: 123, tags: %{}, timestamp: 1234}
-        ])
-        |> RRD.insert(3000, [
-          %{name: "vm.memory.total", type: :last_value, value: 124, tags: %{}, timestamp: 3000}
-        ])
+      v2_data = [
+        {1234,
+         [%{name: "vm.memory.total", type: :last_value, value: 123, tags: %{}, timestamp: 1234}]},
+        {3000,
+         [%{name: "vm.memory.total", type: :last_value, value: 124, tags: %{}, timestamp: 3000}]}
+      ]
+
+      v2_binary = IO.iodata_to_binary([2, :erlang.term_to_binary(v2_data)])
 
       expected_rrd =
         RRD.new(@args)
         |> RRD.insert(1234, {[{"vm.memory.total", :last_value, 123, %{}}], %{}})
         |> RRD.insert(3000, {[{"vm.memory.total", :last_value, 124, %{}}], %{}})
 
-      v2_binary = RRD.save(v2_in_rrd, serialization_version: 2) |> IO.iodata_to_binary()
       assert RRD.load(RRD.new(@args), v2_binary) == {:ok, expected_rrd}
     end
 

--- a/test/mobius/rrd_test.exs
+++ b/test/mobius/rrd_test.exs
@@ -196,6 +196,23 @@ defmodule Mobius.RRDTest do
       assert RRD.load(RRD.new(@args), rrd_binary, histogram_configs: %{}) == {:ok, expected_rrd}
     end
 
+    test "refuses to save with a non-current serialization version" do
+      # save/2 performs no down-conversion, so writing current-shape data
+      # under an old version byte would produce a file that load/3 rejects
+      # as corrupt. save/2 must refuse instead of emitting an unloadable file.
+      rrd =
+        RRD.new(@args)
+        |> RRD.insert(1234, {[{"vm.memory.total", :last_value, 123, %{}}], %{}})
+
+      assert_raise ArgumentError, fn ->
+        RRD.save(rrd, serialization_version: 1)
+      end
+
+      assert_raise ArgumentError, fn ->
+        RRD.save(rrd, serialization_version: 2)
+      end
+    end
+
     test "compression_level changes the payload size but round-trips either way" do
       # redundant data so compression has something to work with
       rrd =

--- a/test/mobius/rrd_test.exs
+++ b/test/mobius/rrd_test.exs
@@ -196,23 +196,6 @@ defmodule Mobius.RRDTest do
       assert RRD.load(RRD.new(@args), rrd_binary, histogram_configs: %{}) == {:ok, expected_rrd}
     end
 
-    test "refuses to save with a non-current serialization version" do
-      # save/2 performs no down-conversion, so writing current-shape data
-      # under an old version byte would produce a file that load/3 rejects
-      # as corrupt. save/2 must refuse instead of emitting an unloadable file.
-      rrd =
-        RRD.new(@args)
-        |> RRD.insert(1234, {[{"vm.memory.total", :last_value, 123, %{}}], %{}})
-
-      assert_raise ArgumentError, fn ->
-        RRD.save(rrd, serialization_version: 1)
-      end
-
-      assert_raise ArgumentError, fn ->
-        RRD.save(rrd, serialization_version: 2)
-      end
-    end
-
     test "compression_level changes the payload size but round-trips either way" do
       # redundant data so compression has something to work with
       rrd =


### PR DESCRIPTION
Closes #123

The first commit is a deliberately failing test confirming the issue: `RRD.save/2` accepts `serialization_version: 1 | 2` but performs no down-conversion, so saving a current-shape RRD under an old version byte silently produces a file that `RRD.load/3` rejects as `DataLoadError{reason: :corrupt}`. The test asserts the intended contract — `save/2` raises `ArgumentError` for non-current versions.

The follow-up commit removes `:serialization_version` from the public `save_opt()` type and docs, makes `save/2` raise on a non-current version, and rewrites the v1/v2 round-trip tests to build their legacy fixture binaries by hand so the load-path coverage for old formats remains.

Local gate also run: `mix format --check-formatted`, `mix credo --strict`, and `mix test` all pass.