### PR TITLE
Make MBF parsing safe and accept float metric values

### DIFF
--- a/lib/mobius/exports/mobius_binary_format.ex
+++ b/lib/mobius/exports/mobius_binary_format.ex
@@ -15,10 +15,15 @@ defmodule Mobius.Exports.MobiusBinaryFormat do
 
   @doc """
   Parse the given binary
+
+  The binary is decoded safely, so atoms in it must already exist in the
+  receiving VM. That holds for the Mobius-defined metric types and tag keys
+  exported by a Mobius peer. Binaries containing unknown atoms are rejected
+  as corrupt.
   """
   @spec parse(binary()) :: {:ok, [Mobius.metric()]} | {:error, Mobius.Exports.MBFParseError.t()}
   def parse(<<@format_version, metrics_bin::binary>>) do
-    metrics = :erlang.binary_to_term(metrics_bin)
+    metrics = :erlang.binary_to_term(metrics_bin, [:safe])
 
     if validate_metrics(metrics) do
       {:ok, metrics}
@@ -38,7 +43,7 @@ defmodule Mobius.Exports.MobiusBinaryFormat do
     Enum.all?(metrics, fn metric ->
       Enum.all?([:name, :tags, :timestamp, :type, :value], &Map.has_key?(metric, &1)) and
         is_binary(metric.name) and
-        is_integer(metric.value) and is_map(metric.tags) and
+        is_number(metric.value) and is_map(metric.tags) and
         is_integer(metric.timestamp) and valid_type?(metric.type)
     end)
   end
@@ -46,6 +51,6 @@ defmodule Mobius.Exports.MobiusBinaryFormat do
   defp validate_metrics(_metrics), do: false
 
   defp valid_type?(type) do
-    type in [:last_value, :counter, :sum, :summary]
+    type in [:last_value, :counter, :sum]
   end
 end

--- a/test/mobius/exports/mobius_binary_format_test.exs
+++ b/test/mobius/exports/mobius_binary_format_test.exs
@@ -1,6 +1,7 @@
 defmodule Mobius.Exports.MobiusBinaryFormatTest do
   use ExUnit.Case, async: true
 
+  alias Mobius.Exports
   alias Mobius.Exports.{MBFParseError, MobiusBinaryFormat}
 
   test "parsing version 1 Mobius Binary Format" do
@@ -13,6 +14,26 @@ defmodule Mobius.Exports.MobiusBinaryFormatTest do
       |> IO.iodata_to_binary()
 
     assert {:ok, ^metrics} = MobiusBinaryFormat.parse(mbf)
+  end
+
+  test "parsing metrics with float values" do
+    metrics = [
+      %{name: "a.b", type: :last_value, value: 1.5, tags: %{}, timestamp: 123}
+    ]
+
+    mbf =
+      MobiusBinaryFormat.to_iodata(metrics)
+      |> IO.iodata_to_binary()
+
+    assert {:ok, ^metrics} = Exports.parse_mbf(mbf)
+  end
+
+  test "parsing does not create atoms unknown to the VM" do
+    name = "mbf_nonexistent_" <> Integer.to_string(:erlang.unique_integer([:positive]))
+    payload = <<131, 100, byte_size(name)::16, name::binary>>
+
+    assert {:error, %MBFParseError{}} = Exports.parse_mbf(<<1, payload::binary>>)
+    assert_raise ArgumentError, fn -> String.to_existing_atom(name) end
   end
 
   test "error parsing mbf binary with wrong metric information" do


### PR DESCRIPTION
Closes #122

Related to #105 (atom hygiene).

The first commit is deliberately failing tests confirming the issue:

- `parse/1` uses `:erlang.binary_to_term/1` without `[:safe]` on wire-format data, so a hand-crafted MBF binary creates arbitrary atoms in the receiving VM.
- `validate_metrics/1` requires `is_integer(metric.value)`, so metrics with float values export fine but fail to parse — the format rejects its own output.

The second commit fixes both:

- Decode with `:erlang.binary_to_term(bin, [:safe])`, keeping the existing rescue into `{:error, %MBFParseError{}}` (`:safe` raises `ArgumentError` on unknown atoms). This means parsing requires the receiving VM to already know the atoms in the binary, which holds for the Mobius-defined types and tag keys exported by a Mobius peer.
- Accept `is_number(metric.value)` in `validate_metrics/1`.
- Remove `:summary` from `valid_type?/1` for consistency: `Exports.mbf/1` strips summary rows before encoding, so a valid MBF binary never contains them — parse is now strict about that.

This repository has no GitHub Actions workflows, so no CI checks will run on this PR. The local gate passed: `mix format --check-formatted`, `mix credo --strict`, and `mix test` are all green.