### PR TITLE
Tolerate a corrupt event log file at boot

### DIFF
--- a/lib/mobius/event_log.ex
+++ b/lib/mobius/event_log.ex
@@ -5,6 +5,8 @@ defmodule Mobius.EventLog do
 
   alias Mobius.{Event, EventsServer}
 
+  require Logger
+
   @event_log_binary_format_version 1
   @default_compression_level 9
 
@@ -81,10 +83,34 @@ defmodule Mobius.EventLog do
   """
   @spec parse(binary()) :: {:ok, [Event.t()]} | {:error, atom()}
   def parse(<<0x01, event_log_bin::binary>>) do
-    {:ok, :erlang.binary_to_term(event_log_bin)}
+    case :erlang.binary_to_term(event_log_bin) do
+      events when is_list(events) ->
+        {:ok, drop_invalid_events(events)}
+
+      _other ->
+        {:error, :corrupt_event_log}
+    end
+  rescue
+    ArgumentError -> {:error, :corrupt_event_log}
   end
 
   def parse(_binary) do
     {:error, :invalid_binary_format}
   end
+
+  # Entries recorded under a different `Event` struct shape (or damaged on
+  # disk) decode to terms that no longer match the current struct, so drop
+  # them rather than letting them crash callers downstream.
+  defp drop_invalid_events(events) do
+    {valid, invalid} = Enum.split_with(events, &valid_event?/1)
+
+    if invalid != [] do
+      Logger.warning("[Mobius] Dropping #{length(invalid)} invalid persisted event log entries")
+    end
+
+    valid
+  end
+
+  defp valid_event?(%Event{} = event), do: Map.keys(event) == Map.keys(%Event{})
+  defp valid_event?(_other), do: false
 end

--- a/lib/mobius/events_server.ex
+++ b/lib/mobius/events_server.ex
@@ -90,7 +90,15 @@ defmodule Mobius.EventsServer do
         CircularBuffer.insert(buff, event)
       end)
     else
-      _ ->
+      {:error, :enoent} ->
+        # Event log file doesn't (yet) exist
+        CircularBuffer.new(log_size)
+
+      {:error, reason} ->
+        Logger.warning(
+          "[Mobius] Could not recover event log from file because #{inspect(reason)}"
+        )
+
         CircularBuffer.new(log_size)
     end
   end

--- a/test/mobius/event_log_test.exs
+++ b/test/mobius/event_log_test.exs
@@ -50,6 +50,10 @@ defmodule Mobius.EventLogTest do
     assert event_log == events
   end
 
+  test "parse/1 returns an error tuple for a corrupt v1 payload" do
+    assert {:error, _reason} = EventLog.parse(<<0x01, 255, 254, 253, 252>>)
+  end
+
   @tag :tmp_dir
   test "save persists the event log so a fresh instance restores it", %{tmp_dir: tmp_dir} do
     instance = :event_log_roundtrip

--- a/test/mobius/event_log_test.exs
+++ b/test/mobius/event_log_test.exs
@@ -54,6 +54,18 @@ defmodule Mobius.EventLogTest do
     assert {:error, _reason} = EventLog.parse(<<0x01, 255, 254, 253, 252>>)
   end
 
+  test "parse/1 rejects a v1 payload that is not a list of events" do
+    assert {:error, _reason} = EventLog.parse(<<0x01, :erlang.term_to_binary(:boom)::binary>>)
+  end
+
+  @tag capture_log: true
+  test "parse/1 drops entries that are not the current Event struct" do
+    event = Event.new("test", "a.b.c", %{a: 1}, %{}, timestamp: 1)
+    bin = <<0x01, :erlang.term_to_binary([event, %{not: :an_event}, :junk])::binary>>
+
+    assert {:ok, [^event]} = EventLog.parse(bin)
+  end
+
   @tag :tmp_dir
   test "save persists the event log so a fresh instance restores it", %{tmp_dir: tmp_dir} do
     instance = :event_log_roundtrip

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -29,6 +29,21 @@ defmodule MobiusTest do
   end
 
   @tag capture_log: true
+  @tag :tmp_dir
+  test "does not crash with a corrupt event log file", %{tmp_dir: tmp_dir} do
+    persistence_path = Path.join(tmp_dir, @default_instance_str)
+    File.mkdir_p!(persistence_path)
+
+    # A valid version byte followed by a payload that does not decode as a term
+    File.write!(Path.join(persistence_path, "event_log"), <<0x01, 255, 254, 253, 252>>)
+
+    assert {:ok, _pid} = start_supervised({Mobius, persistence_dir: tmp_dir, metrics: []})
+
+    # The corrupt log is dropped and the instance starts with an empty event log
+    assert Mobius.EventLog.list() == []
+  end
+
+  @tag capture_log: true
   test "boots without persistence when the persistence dir cannot be created" do
     # A file sits where the directory tree should go: mkdir_p cannot succeed.
     bad_parent = Path.join(@persistence_dir, "not_a_dir")


### PR DESCRIPTION
Closes #118

The first commit is a deliberately failing test pair confirming the issue: `EventLog.parse/1` raises `ArgumentError` on a corrupt v1 payload instead of returning an error tuple, and a corrupt `event_log` file on disk crashes `EventsServer.init`, preventing the whole Mobius instance from booting.

The second commit wraps the decode so `parse/1` returns `{:error, _}` for any undecodable or wrongly-shaped payload (it must be a list of `%Mobius.Event{}`; entries that don't match the current struct shape are dropped), and has `EventsServer` fall back to an empty buffer with a warning, matching the graceful RRD and metrics-table loaders.

Verified locally: `mix format --check-formatted`, `mix credo --strict`, and `mix test` all pass, and the lib compiles with `--warnings-as-errors` on Elixir 1.20.0-rc.1.