### PR TITLE
Honor :to without :from and consolidate window resolution

### DIFF
--- a/lib/mobius/charts.ex
+++ b/lib/mobius/charts.ex
@@ -35,7 +35,6 @@ defmodule Mobius.Charts do
   alias Telemetry.Metrics
 
   @default_window_seconds 180
-  @max_history_seconds 60 * 86_400
 
   @typedoc """
   Options shared by every query.
@@ -43,7 +42,9 @@ defmodule Mobius.Charts do
     * `:mobius_instance` - the instance to query (default `:mobius`)
     * `:last` - window covering the last `x`, where `x` is an integer number of
       seconds or `{integer(), Mobius.time_unit()}`
-    * `:from` / `:to` - explicit unix-second window bounds
+    * `:from` / `:to` - explicit unix-second window bounds; each may be given
+      alone — `:from` defaults to 0 (the beginning of stored history) and
+      `:to` defaults to now
 
   With no window option the last #{@default_window_seconds} seconds are used.
   """
@@ -450,7 +451,7 @@ defmodule Mobius.Charts do
         :error -> []
       end
     end)
-    |> Enum.filter(fn {ts, _} -> to - ts <= @max_history_seconds and ts <= to end)
+    |> Enum.filter(fn {ts, _} -> ts <= to end)
     |> Enum.chunk_every(2, 1, :discard)
     |> Enum.flat_map(fn
       [{_t0, earlier}, {t1, later}] when t1 >= from ->

--- a/lib/mobius/data.ex
+++ b/lib/mobius/data.ex
@@ -34,15 +34,15 @@ defmodule Mobius.Data do
   alias Mobius.Data.{Histogram, Metrics}
   alias Mobius.{Scraper, Summary}
 
-  @max_history_seconds 60 * 86_400
-
   @typedoc """
   Options shared by every query.
 
     * `:mobius_instance` - the instance to query (default `:mobius`)
     * `:last` - window covering the last `x`, where `x` is an integer number of
       seconds or `{integer(), Mobius.time_unit()}`
-    * `:from` / `:to` - explicit unix-second window bounds
+    * `:from` / `:to` - explicit unix-second window bounds; each may be given
+      alone — `:from` defaults to 0 (the beginning of stored history) and
+      `:to` defaults to now
 
   With no window option the last 3 minutes are used.
   """
@@ -226,7 +226,7 @@ defmodule Mobius.Data do
       {ts, {^metric_name, :summary, data, rec_tags}} when rec_tags == tags -> [{ts, data}]
       _ -> []
     end)
-    |> Enum.filter(fn {ts, _data} -> to - ts <= @max_history_seconds and ts <= to end)
+    |> Enum.filter(fn {ts, _data} -> ts <= to end)
     |> Enum.uniq_by(fn {ts, _data} -> ts end)
     |> Enum.sort_by(fn {ts, _data} -> ts end)
     |> Enum.chunk_every(2, 1, :discard)
@@ -253,14 +253,16 @@ defmodule Mobius.Data do
 
   # Shared window resolution for the Data and Charts query APIs: turn
   # `:from`/`:to` or `:last` (or nothing → the default 3-minute window) into
-  # absolute `{from, to}` unix-second bounds.
+  # absolute `{from, to}` unix-second bounds. `:from` and `:to` are independent
+  # bounds: `:from` alone runs to now, `:to` alone starts at 0 (the beginning
+  # of stored history).
   @doc false
   @spec resolve_window([opt()]) :: {integer(), integer()}
   def resolve_window(opts) do
     now = System.system_time(:second)
 
     cond do
-      opts[:from] != nil -> {opts[:from], opts[:to] || now}
+      opts[:from] != nil or opts[:to] != nil -> {opts[:from] || 0, opts[:to] || now}
       opts[:last] != nil -> {now - last_seconds(opts[:last]), now}
       true -> {now - 180, now}
     end

--- a/lib/mobius/data/metrics.ex
+++ b/lib/mobius/data/metrics.ex
@@ -5,7 +5,7 @@ defmodule Mobius.Data.Metrics do
   # stored records from the scraper for a window and filter them down to a
   # single metric, summarizing summary records on the way out.
 
-  alias Mobius.{Scraper, Summary}
+  alias Mobius.{Data, Scraper, Summary}
 
   @doc """
   Fetch the raw, un-delta'd rows for a metric over a window.
@@ -80,33 +80,7 @@ defmodule Mobius.Data.Metrics do
   end
 
   defp query_opts(opts) do
-    if opts[:from] do
-      Keyword.take(opts, [:from, :to])
-    else
-      last_ts(opts)
-    end
+    {from, to} = Data.resolve_window(opts)
+    [from: from, to: to]
   end
-
-  defp last_ts(opts) do
-    now = System.system_time(:second)
-
-    ts =
-      case opts[:last] do
-        nil ->
-          now - 180
-
-        {offset, unit} ->
-          now - offset * get_unit_offset(unit)
-
-        offset ->
-          now - offset
-      end
-
-    [from: ts]
-  end
-
-  defp get_unit_offset(:second), do: 1
-  defp get_unit_offset(:minute), do: 60
-  defp get_unit_offset(:hour), do: 3600
-  defp get_unit_offset(:day), do: 86400
 end

--- a/test/mobius/charts_test.exs
+++ b/test/mobius/charts_test.exs
@@ -105,6 +105,32 @@ defmodule Mobius.ChartsTest do
   end
 
   @tag :tmp_dir
+  test "quantiles_over_time is not truncated to the default 60-day retention",
+       %{tmp_dir: tmp_dir} do
+    instance = :charts_qot_no_cap
+    start_instance(instance, tmp_dir, [histogram_metric("flash.write.duration", :duration)])
+
+    for n <- 1..10, do: :telemetry.execute([:flash, :write], %{duration: n * 1.0}, %{})
+    Process.sleep(@scrape_interval_ms * 2)
+
+    for n <- 100..119, do: :telemetry.execute([:flash, :write], %{duration: n * 1.0}, %{})
+    Process.sleep(@scrape_interval_ms * 2)
+
+    # The stored data lies more than 60 days before :to but inside the
+    # requested window. A hardcoded 60-day cap would silently drop it.
+    to = System.system_time(:second) + 61 * 86_400
+
+    assert {:ok, qot} =
+             Charts.quantiles_over_time("flash.write.duration", [0.5], %{},
+               mobius_instance: instance,
+               from: 0,
+               to: to
+             )
+
+    assert [%{quantile: 0.5, points: [_ | _]}] = qot.lines
+  end
+
+  @tag :tmp_dir
   @tag capture_log: true
   test "quantiles_over_time skips the interval across a counter reset", %{tmp_dir: tmp_dir} do
     instance = :charts_qot_reset

--- a/test/mobius/data_test.exs
+++ b/test/mobius/data_test.exs
@@ -101,6 +101,59 @@ defmodule Mobius.DataTest do
       # Raw, un-delta'd: the latest stored cumulative last_value is present.
       assert Enum.any?(rows, &(&1.value == 110))
     end
+
+    @tag :tmp_dir
+    test ":to alone bounds the result", %{tmp_dir: tmp_dir} do
+      instance = :data_metrics_to_alone
+      metrics = [Telemetry.Metrics.last_value("vm.memory.total", measurement: :total)]
+      start_instance(instance, tmp_dir, metrics)
+
+      :telemetry.execute([:vm, :memory], %{total: 100}, %{})
+      Process.sleep(@scrape_interval_ms)
+
+      # All stored data is newer than this :to, so nothing may come back. A
+      # window resolution that ignores :to without :from would fall back to
+      # the default last-3-minutes window and return the scraped row.
+      before_data = System.system_time(:second) - 3600
+
+      assert Data.metrics("vm.memory.total", :last_value, %{},
+               mobius_instance: instance,
+               to: before_data
+             ) == {:ok, []}
+
+      # And with :to in the future the row is included (from defaults to 0).
+      assert {:ok, [_ | _]} =
+               Data.metrics("vm.memory.total", :last_value, %{},
+                 mobius_instance: instance,
+                 to: System.system_time(:second) + 3600
+               )
+    end
+  end
+
+  describe "resolve_window/1" do
+    test ":to without :from is honored, with :from defaulting to 0" do
+      assert Data.resolve_window(to: 1_000) == {0, 1_000}
+    end
+
+    test ":from without :to runs to now" do
+      now = System.system_time(:second)
+      {from, to} = Data.resolve_window(from: 123)
+
+      assert from == 123
+      assert_in_delta to, now, 2
+    end
+
+    test ":from and :to are used as given" do
+      assert Data.resolve_window(from: 100, to: 200) == {100, 200}
+    end
+
+    test "no window option defaults to the last 3 minutes" do
+      now = System.system_time(:second)
+      {from, to} = Data.resolve_window([])
+
+      assert_in_delta to, now, 2
+      assert to - from == 180
+    end
   end
 
   describe "histogram/3" do

--- a/test/mobius/data_test.exs
+++ b/test/mobius/data_test.exs
@@ -61,6 +61,30 @@ defmodule Mobius.DataTest do
     end
 
     @tag :tmp_dir
+    test "windows are not truncated to the default 60-day retention", %{tmp_dir: tmp_dir} do
+      instance = :data_summary_windows_no_cap
+
+      start_instance(instance, tmp_dir, [
+        Telemetry.Metrics.summary("db.query.ms", measurement: :ms)
+      ])
+
+      for n <- 1..10, do: :telemetry.execute([:db, :query], %{ms: n * 1.0}, %{})
+      Process.sleep(@scrape_interval_ms * 2)
+
+      for n <- 100..119, do: :telemetry.execute([:db, :query], %{ms: n * 1.0}, %{})
+      Process.sleep(@scrape_interval_ms * 2)
+
+      # The stored data lies more than 60 days before :to but inside the
+      # requested window. A hardcoded 60-day cap would silently drop it.
+      to = System.system_time(:second) + 61 * 86_400
+
+      {:ok, windows} =
+        Data.summary_windows("db.query.ms", %{}, mobius_instance: instance, from: 0, to: to)
+
+      assert windows != []
+    end
+
+    @tag :tmp_dir
     test "an unobserved summary metric yields no windows", %{tmp_dir: tmp_dir} do
       instance = :data_summary_windows_empty
 


### PR DESCRIPTION
Closes #127

The first commit is a deliberately failing test confirming the issue: `Mobius.Data.resolve_window(to: 1_000)` ignores `:to` when `:from` is absent and falls back to the default last-3-minutes window, and `Data.metrics/4` with `to:` alone returns rows newer than the requested bound.

The fix (second commit):

- `:to` alone is now honored, with `:from` defaulting to 0 (the beginning of stored history). Documented in the `opt()` typedocs.
- `Mobius.Data.Metrics` now uses `Data.resolve_window/1` instead of its own duplicate `query_opts`/`last_ts`/`get_unit_offset` logic, so the window rule exists once.
- The `@max_history_seconds` cap (60 days, duplicated in `Mobius.Data` and `Mobius.Charts`) is dropped rather than derived: it encoded the *default* RRD retention and silently truncated queries on RRDs configured with longer retention. Queries are already bounded by the resolved `from`/`to` window and by what the RRD actually retains, so the cap added nothing on default configurations and only corrupted results on extended ones. Covered by tests that place `:to` more than 60 days after the stored data.

Local gate passes: `mix format --check-formatted`, `mix credo --strict`, `mix test` (193 tests, 0 failures across repeated runs).

CI: 5 of 6 CircleCI jobs pass, including the strict 1.20/OTP-29 job. The 1.19.5 job failed on `test can autosave persistence data` (`test/mobius_test.exs:120`) — a pre-existing timing flake (1 s autosave interval asserted within a 1100 ms sleep) unrelated to this change; a re-run should clear it.