### PR TITLE
Close the fd when an atomic save fails

### DIFF
--- a/lib/mobius/events_server.ex
+++ b/lib/mobius/events_server.ex
@@ -3,7 +3,7 @@ defmodule Mobius.EventsServer do
 
   use GenServer
 
-  alias Mobius.{Event, EventLog, TimeServer}
+  alias Mobius.{Event, EventLog, Persistence, TimeServer}
 
   require Logger
 
@@ -206,29 +206,12 @@ defmodule Mobius.EventsServer do
   end
 
   defp do_save(binary, state) do
-    # Write-to-tmp + fsync + rename so a power cut mid-write leaves the
-    # previous event log intact instead of a truncated one. The persistence
-    # directory may have been unavailable at boot (or gone away since), so
-    # re-create it on every attempt — saving recovers as soon as the
-    # filesystem allows.
-    _ = File.mkdir_p(state.persistence_dir)
-    path = make_file_path(state.persistence_dir)
-    tmp = path <> ".tmp"
-
-    result =
-      with {:ok, fd} <- File.open(tmp, [:write, :binary]),
-           :ok <- IO.binwrite(fd, binary),
-           :ok <- :file.sync(fd),
-           :ok <- File.close(fd) do
-        File.rename(tmp, path)
-      end
-
-    case result do
+    # See Mobius.Persistence for the write-to-tmp + fsync + rename details.
+    case Persistence.write_atomic(state.persistence_dir, @file_name, binary) do
       :ok ->
         :ok
 
       {:error, reason} ->
-        _ = File.rm(tmp)
         Logger.warning("[Mobius]: unable to save event log: #{inspect(reason)}")
         :ok
     end

--- a/lib/mobius/persistence.ex
+++ b/lib/mobius/persistence.ex
@@ -27,18 +27,13 @@ defmodule Mobius.Persistence do
   """
   @spec write_atomic(Path.t(), String.t(), iodata(), [opt()]) :: :ok | {:error, term()}
   def write_atomic(dir, filename, contents, opts \\ []) do
-    write_fun = Keyword.get(opts, :write_fun, &IO.binwrite/2)
-    sync_fun = Keyword.get(opts, :sync_fun, &:file.sync/1)
-
     _ = File.mkdir_p(dir)
     path = Path.join(dir, filename)
     tmp = path <> ".tmp"
 
     result =
       with {:ok, fd} <- File.open(tmp, [:write, :binary]),
-           :ok <- write_fun.(fd, contents),
-           :ok <- sync_fun.(fd),
-           :ok <- File.close(fd) do
+           :ok <- write_sync_close(fd, contents, opts) do
         File.rename(tmp, path)
       end
 
@@ -49,6 +44,24 @@ defmodule Mobius.Persistence do
       error ->
         _ = File.rm(tmp)
         error
+    end
+  end
+
+  # Close the device on every path — the callers are long-lived GenServers,
+  # so a descriptor leaked when the write or sync fails (disk full surfaces
+  # exactly there) would never be reclaimed.
+  defp write_sync_close(fd, contents, opts) do
+    write_fun = Keyword.get(opts, :write_fun, &IO.binwrite/2)
+    sync_fun = Keyword.get(opts, :sync_fun, &:file.sync/1)
+
+    result =
+      with :ok <- write_fun.(fd, contents) do
+        sync_fun.(fd)
+      end
+
+    case {result, File.close(fd)} do
+      {:ok, close_result} -> close_result
+      {error, _close_result} -> error
     end
   end
 end

--- a/lib/mobius/persistence.ex
+++ b/lib/mobius/persistence.ex
@@ -1,0 +1,54 @@
+defmodule Mobius.Persistence do
+  @moduledoc false
+
+  # Shared atomic file write used by the persistence save paths
+  # (Mobius.Scraper and Mobius.EventsServer).
+
+  @typedoc """
+  Test seams for the write and sync steps
+
+  Production callers never pass these; they default to the real
+  `IO.binwrite/2` and `:file.sync/1`.
+  """
+  @type opt() ::
+          {:write_fun, (File.io_device(), iodata() -> :ok | {:error, term()})}
+          | {:sync_fun, (File.io_device() -> :ok | {:error, term()})}
+
+  @doc """
+  Atomically write `contents` to `filename` inside `dir`
+
+  Write-to-tmp + fsync + rename so a power cut mid-write leaves the previous
+  file intact instead of a truncated one the next boot cannot load. The
+  persistence directory may have been unavailable at boot (or gone away
+  since), so re-create it on every attempt.
+
+  On failure the temp file is removed and the error returned; logging is left
+  to the caller.
+  """
+  @spec write_atomic(Path.t(), String.t(), iodata(), [opt()]) :: :ok | {:error, term()}
+  def write_atomic(dir, filename, contents, opts \\ []) do
+    write_fun = Keyword.get(opts, :write_fun, &IO.binwrite/2)
+    sync_fun = Keyword.get(opts, :sync_fun, &:file.sync/1)
+
+    _ = File.mkdir_p(dir)
+    path = Path.join(dir, filename)
+    tmp = path <> ".tmp"
+
+    result =
+      with {:ok, fd} <- File.open(tmp, [:write, :binary]),
+           :ok <- write_fun.(fd, contents),
+           :ok <- sync_fun.(fd),
+           :ok <- File.close(fd) do
+        File.rename(tmp, path)
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      error ->
+        _ = File.rm(tmp)
+        error
+    end
+  end
+end

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -3,11 +3,12 @@ defmodule Mobius.Scraper do
 
   use GenServer
 
-  alias Mobius.{Events, MetricsTable, RRD}
+  alias Mobius.{Events, MetricsTable, Persistence, RRD}
 
   require Logger
 
   @interval 1_000
+  @file_name "history"
 
   @doc """
   Start the scraper server
@@ -115,7 +116,7 @@ defmodule Mobius.Scraper do
   end
 
   defp file(state) do
-    Path.join(state.persistence_dir, "history")
+    Path.join(state.persistence_dir, @file_name)
   end
 
   @typedoc """
@@ -279,37 +280,20 @@ defmodule Mobius.Scraper do
     save_to_persistence(state)
   end
 
-  # Write our database to persistent storage. Write-to-tmp + fsync + rename so a
-  # power cut mid-write leaves the previous file intact instead of a truncated one
-  # the next boot cannot load (and would then overwrite on its first autosave).
-  # The persistence directory may have been unavailable at boot (or gone away
-  # since), so re-create it on every attempt.
+  # Write our database to persistent storage. See Mobius.Persistence for the
+  # write-to-tmp + fsync + rename details.
   defp save_to_persistence(state) do
-    path = file(state)
-    tmp = path <> ".tmp"
-
     contents =
       RRD.save(state.database,
         histogram_configs: state.histogram_configs,
         compression_level: state.compression_level
       )
 
-    _ = File.mkdir_p(state.persistence_dir)
-
-    result =
-      with {:ok, fd} <- File.open(tmp, [:write, :binary]),
-           :ok <- IO.binwrite(fd, contents),
-           :ok <- :file.sync(fd),
-           :ok <- File.close(fd) do
-        File.rename(tmp, path)
-      end
-
-    case result do
+    case Persistence.write_atomic(state.persistence_dir, @file_name, contents) do
       :ok ->
         :ok
 
       error ->
-        _ = File.rm(tmp)
         Logger.warning("Failed to save metrics history because #{inspect(error)}")
 
         error

--- a/test/mobius/persistence_test.exs
+++ b/test/mobius/persistence_test.exs
@@ -1,0 +1,60 @@
+defmodule Mobius.PersistenceTest do
+  use ExUnit.Case, async: true
+
+  alias Mobius.Persistence
+
+  setup do
+    dir =
+      Path.join(System.tmp_dir!(), "mobius_persistence_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    {:ok, dir: dir}
+  end
+
+  test "writes the file and leaves no temp file behind", %{dir: dir} do
+    assert :ok = Persistence.write_atomic(dir, "history", "contents")
+
+    assert File.read!(Path.join(dir, "history")) == "contents"
+    refute File.exists?(Path.join(dir, "history.tmp"))
+  end
+
+  test "a failed write returns the error, removes the temp file and closes the device", %{
+    dir: dir
+  } do
+    test_pid = self()
+
+    write_fun = fn fd, _contents ->
+      send(test_pid, {:device, fd})
+      {:error, :enospc}
+    end
+
+    assert {:error, :enospc} =
+             Persistence.write_atomic(dir, "history", "contents", write_fun: write_fun)
+
+    assert_receive {:device, fd}
+    refute File.exists?(Path.join(dir, "history.tmp"))
+    # The io device must be closed on the error path — the callers are
+    # long-lived GenServers, so a leaked device is never reclaimed.
+    refute Process.alive?(fd)
+  end
+
+  test "a failed sync returns the error, removes the temp file and closes the device", %{
+    dir: dir
+  } do
+    test_pid = self()
+
+    sync_fun = fn fd ->
+      send(test_pid, {:device, fd})
+      {:error, :enospc}
+    end
+
+    assert {:error, :enospc} =
+             Persistence.write_atomic(dir, "history", "contents", sync_fun: sync_fun)
+
+    assert_receive {:device, fd}
+    refute File.exists?(Path.join(dir, "history.tmp"))
+    refute Process.alive?(fd)
+  end
+end


### PR DESCRIPTION
Closes #121

Both `Mobius.Scraper.save_to_persistence/1` and `Mobius.EventsServer.do_save/2` left the io device open when `IO.binwrite` or `:file.sync` failed (disk full surfaces exactly there). The owning GenServers are long-lived, so descriptors leaked indefinitely under the 60-second autosave against a full or flaky filesystem.

The first commit is a deliberately failing test confirming the leak: since a real `enospc` is hard to reproduce on macOS, it extracts the duplicated write sequence verbatim (still buggy) into `Mobius.Persistence.write_atomic/4` with injectable write/sync steps as a test-only seam, and asserts the io device process is no longer alive after a failed save. The second commit closes the device on every path and switches both call sites to the shared helper.

Verified locally: `mix format --check-formatted`, `mix credo --strict` and `mix test` all pass, plus a clean `--warnings-as-errors` compile on Elixir 1.20.0-rc.1.