### PR TITLE
Catch throws and exits in telemetry handlers

### DIFF
--- a/lib/mobius/events.ex
+++ b/lib/mobius/events.ex
@@ -143,9 +143,8 @@ defmodule Mobius.Events do
           Logger.error("Could not format metric #{inspect(metric)}")
           Logger.error(Exception.format(:error, e, __STACKTRACE__))
       catch
-        # A throw or exit from a user-supplied callback must not escape to
-        # :telemetry, which would permanently detach the handler — Mobius is
-        # observability and must never silently stop the app's metrics.
+        # A throw or exit must not escape to :telemetry — it would
+        # permanently detach this handler.
         kind, reason ->
           Logger.error("Could not format metric #{inspect(metric)}")
           Logger.error(Exception.format(kind, reason, __STACKTRACE__))
@@ -312,9 +311,8 @@ defmodule Mobius.Events do
         Logger.error("Could not process event #{inspect(event)}")
         Logger.error(Exception.format(:error, e, __STACKTRACE__))
     catch
-      # A throw or exit from a user-supplied callback must not escape to
-      # :telemetry, which would permanently detach the handler — Mobius is
-      # observability and must never silently stop the app's events.
+      # A throw or exit must not escape to :telemetry — it would
+      # permanently detach this handler.
       kind, reason ->
         Logger.error("Could not process event #{inspect(event)}")
         Logger.error(Exception.format(kind, reason, __STACKTRACE__))

--- a/lib/mobius/events.ex
+++ b/lib/mobius/events.ex
@@ -142,6 +142,13 @@ defmodule Mobius.Events do
         e ->
           Logger.error("Could not format metric #{inspect(metric)}")
           Logger.error(Exception.format(:error, e, __STACKTRACE__))
+      catch
+        # A throw or exit from a user-supplied callback must not escape to
+        # :telemetry, which would permanently detach the handler — Mobius is
+        # observability and must never silently stop the app's metrics.
+        kind, reason ->
+          Logger.error("Could not format metric #{inspect(metric)}")
+          Logger.error(Exception.format(kind, reason, __STACKTRACE__))
       end
     end
 
@@ -304,6 +311,13 @@ defmodule Mobius.Events do
       e ->
         Logger.error("Could not process event #{inspect(event)}")
         Logger.error(Exception.format(:error, e, __STACKTRACE__))
+    catch
+      # A throw or exit from a user-supplied callback must not escape to
+      # :telemetry, which would permanently detach the handler — Mobius is
+      # observability and must never silently stop the app's events.
+      kind, reason ->
+        Logger.error("Could not process event #{inspect(event)}")
+        Logger.error(Exception.format(kind, reason, __STACKTRACE__))
     end
 
     :ok

--- a/test/mobius/events_test.exs
+++ b/test/mobius/events_test.exs
@@ -140,6 +140,73 @@ defmodule Mobius.EventsTest do
 
   @histogram_table :mobius_test_histogram_metric
 
+  describe "user callbacks that throw" do
+    @tag capture_log: true
+    test "a throwing measurement function must not detach the metrics handler", %{table: table} do
+      event = [:events, :test, :crash]
+      handler_id = {__MODULE__, event, self()}
+
+      bad =
+        Metrics.last_value("events.test.crash.bad",
+          measurement: fn _measurements -> throw(:boom) end
+        )
+
+      good = Metrics.last_value("events.test.crash.good", measurement: :value)
+
+      config = Events.metric_handler_config(table, [bad, good])
+      :ok = :telemetry.attach(handler_id, event, &Events.handle_metrics/4, config)
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # The bad metric throws — if that escapes to :telemetry the whole
+      # handler is permanently detached and metrics silently stop.
+      :telemetry.execute(event, %{value: 1}, %{})
+
+      assert Enum.any?(:telemetry.list_handlers(event), &(&1.id == handler_id))
+
+      # A later event for the well-behaved metric must still be recorded
+      :telemetry.execute(event, %{value: 42}, %{})
+
+      assert [{"events.test.crash.good", :last_value, 42, %{}}] =
+               MetricsTable.get_entries_by_metric_name(table, "events.test.crash.good")
+    end
+
+    @tag :tmp_dir
+    @tag capture_log: true
+    test "a throwing measurements translator must not detach the event handler", %{
+      tmp_dir: tmp_dir
+    } do
+      start_supervised!({Mobius, mobius_instance: :crashing_event, persistence_dir: tmp_dir})
+
+      event = [:events, :test, :event_crash]
+      handler_id = {__MODULE__, event, self()}
+
+      config = %{
+        table: :crashing_event,
+        event_opts: [
+          measurements_values: fn
+            {:boom, _value} -> throw(:boom)
+            {_key, value} -> value
+          end
+        ],
+        session: "test"
+      }
+
+      :ok = :telemetry.attach(handler_id, event, &Events.handle_event/4, config)
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      :telemetry.execute(event, %{boom: 1}, %{})
+
+      assert Enum.any?(:telemetry.list_handlers(event), &(&1.id == handler_id))
+
+      # A later well-behaved event must still be recorded
+      :telemetry.execute(event, %{a: 1}, %{})
+
+      assert [recorded] = Mobius.EventLog.list(instance: :crashing_event)
+      assert recorded.name == "events.test.event_crash"
+      assert recorded.measurements == %{a: 1}
+    end
+  end
+
   describe "histogram-enabled summary metric" do
     setup do
       # A stable, compile-time table name. Tests in a module run sequentially


### PR DESCRIPTION
Closes #126

`Events.handle_metrics/4` and `Events.handle_event/4` only `rescue` exceptions from user-supplied callbacks (`measurement`, `keep`, `tag_values`, `measurements_values`). A `throw` or `exit` escapes to `:telemetry`, which permanently detaches the handler — metrics and events silently stop for the rest of the run.

The first commit is a deliberately failing test pair confirming the issue: a metric whose measurement function throws gets the whole handler group detached, so a well-behaved metric on the same event stops being recorded. The second commit catches all three error classes (`rescue` plus `catch kind, reason`) and logs them, matching the existing rescue behavior.

Locally verified with `mix format --check-formatted`, `mix credo --strict`, and `mix test`, plus a warnings-as-errors compile on Elixir 1.20.0-rc.1.