### PR TITLE
Make Charts.series honor the Mobius.Data no-crash contract

### DIFF
--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -512,7 +512,7 @@ defmodule Mobius do
         "type: {:summary, :average}, or use Mobius.current/2 for the histogram."
 
   defp explain(:unavailable),
-    do: "Mobius is not available to answer queries right now. Is the instance running?"
+    do: "The Mobius instance is not running or did not respond."
 
   defp explain({:invalid_summary_field, field}),
     do: "#{inspect(field)} is not a summary field. Use :average, :std_dev, or :reports."

--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -420,9 +420,8 @@ defmodule Mobius do
     query_opts = Keyword.put(opts, :mobius_instance, instance)
 
     with {:ok, type} <- resolve_type(metric_name, opts, instance),
-         :ok <- ensure_plottable(type) do
-      %{points: points} = Charts.series(metric_name, type, tags, query_opts)
-
+         :ok <- ensure_plottable(type),
+         {:ok, %{points: points}} <- Charts.series(metric_name, type, tags, query_opts) do
       case Plot.line(points, opts) do
         {:ok, chart} ->
           IO.puts([chart_header(metric_name, type, tags), "\n\n", chart])
@@ -511,4 +510,10 @@ defmodule Mobius do
     do:
       "Summary metrics are not plottable directly. Plot a field with " <>
         "type: {:summary, :average}, or use Mobius.current/2 for the histogram."
+
+  defp explain(:unavailable),
+    do: "Mobius is not available to answer queries right now. Is the instance running?"
+
+  defp explain({:invalid_summary_field, field}),
+    do: "#{inspect(field)} is not a summary field. Use :average, :std_dev, or :reports."
 end

--- a/lib/mobius/charts.ex
+++ b/lib/mobius/charts.ex
@@ -243,10 +243,15 @@ defmodule Mobius.Charts do
   the same idea `DDSketch.delta/2` applies to histograms. A snapshot interval
   with no new reports contributes no point.
 
-      avg = Mobius.Charts.series("http.request.duration", {:summary, :average}, %{}, last: {1, :hour})
+  Returns `{:error, :unavailable}` when the instance is down or too busy to
+  answer (see `Mobius.Data`), and `{:error, {:invalid_summary_field, field}}`
+  for a summary field other than `:average`, `:std_dev`, or `:reports`.
+
+      {:ok, avg} = Mobius.Charts.series("http.request.duration", {:summary, :average}, %{}, last: {1, :hour})
       # avg.points => [%{timestamp: ..., value: 12.4}, ...]
   """
-  @spec series(Mobius.metric_name(), metric_type(), map(), [opt()]) :: series()
+  @spec series(Mobius.metric_name(), metric_type(), map(), [opt()]) ::
+          {:ok, series()} | {:error, term()}
   def series(metric_name, type, tags \\ %{}, opts \\ [])
 
   def series(metric_name, :summary, tags, opts) do
@@ -258,13 +263,16 @@ defmodule Mobius.Charts do
       |> Data.summary_deltas(metric_name, tags, from, to)
       |> Enum.map(fn {ts, delta} -> %{timestamp: ts, value: Summary.calculate(delta)} end)
 
-    %{
-      metric: metric_name,
-      type: :summary,
-      tags: tags,
-      window: %{from: from, to: to},
-      points: points
-    }
+    {:ok,
+     %{
+       metric: metric_name,
+       type: :summary,
+       tags: tags,
+       window: %{from: from, to: to},
+       points: points
+     }}
+  catch
+    :exit, _reason -> {:error, :unavailable}
   end
 
   def series(metric_name, {:summary, field} = type, tags, opts)
@@ -279,30 +287,39 @@ defmodule Mobius.Charts do
         %{timestamp: ts, value: Map.fetch!(Summary.calculate(delta), field)}
       end)
 
-    %{
-      metric: metric_name,
-      type: type,
-      tags: tags,
-      window: %{from: from, to: to},
-      points: points
-    }
+    {:ok,
+     %{
+       metric: metric_name,
+       type: type,
+       tags: tags,
+       window: %{from: from, to: to},
+       points: points
+     }}
+  catch
+    :exit, _reason -> {:error, :unavailable}
+  end
+
+  def series(_metric_name, {:summary, field}, _tags, _opts) do
+    {:error, {:invalid_summary_field, field}}
   end
 
   def series(metric_name, type, tags, opts) do
     {from, to} = Data.resolve_window(opts)
 
-    {:ok, rows} = Data.metrics(metric_name, type, tags, Keyword.merge(opts, from: from, to: to))
+    with {:ok, rows} <-
+           Data.metrics(metric_name, type, tags, Keyword.merge(opts, from: from, to: to)) do
+      points =
+        Enum.map(rows, fn %{timestamp: ts, value: value} -> %{timestamp: ts, value: value} end)
 
-    points =
-      Enum.map(rows, fn %{timestamp: ts, value: value} -> %{timestamp: ts, value: value} end)
-
-    %{
-      metric: metric_name,
-      type: type,
-      tags: tags,
-      window: %{from: from, to: to},
-      points: points
-    }
+      {:ok,
+       %{
+         metric: metric_name,
+         type: type,
+         tags: tags,
+         window: %{from: from, to: to},
+         points: points
+       }}
+    end
   end
 
   @doc """

--- a/test/mobius/charts_test.exs
+++ b/test/mobius/charts_test.exs
@@ -182,6 +182,40 @@ defmodule Mobius.ChartsTest do
     assert timestamps == Enum.sort(timestamps)
   end
 
+  test "series returns {:error, :unavailable} when the instance is not running" do
+    assert {:error, :unavailable} =
+             Charts.series("some.metric", :last_value, %{},
+               mobius_instance: :charts_not_running_test
+             )
+  end
+
+  test "series returns {:error, :unavailable} for summary types when the instance is not running" do
+    assert {:error, :unavailable} =
+             Charts.series("some.metric", :summary, %{},
+               mobius_instance: :charts_not_running_test
+             )
+
+    assert {:error, :unavailable} =
+             Charts.series("some.metric", {:summary, :average}, %{},
+               mobius_instance: :charts_not_running_test
+             )
+  end
+
+  @tag :tmp_dir
+  test "series rejects an unknown summary field", %{tmp_dir: tmp_dir} do
+    instance = :charts_series_bad_field
+    metrics = [Telemetry.Metrics.summary("http.request.duration", measurement: :duration)]
+    start_instance(instance, tmp_dir, metrics)
+
+    :telemetry.execute([:http, :request], %{duration: 12.0}, %{})
+    Process.sleep(@scrape_interval_ms)
+
+    assert {:error, {:invalid_summary_field, :p99}} =
+             Charts.series("http.request.duration", {:summary, :p99}, %{},
+               mobius_instance: instance
+             )
+  end
+
   @tag :tmp_dir
   test "latest returns the most recent value per metric and skips empty ones",
        %{tmp_dir: tmp_dir} do

--- a/test/mobius/charts_test.exs
+++ b/test/mobius/charts_test.exs
@@ -170,7 +170,8 @@ defmodule Mobius.ChartsTest do
     :telemetry.execute([:device, :temp], %{celsius: 42.0}, %{})
     Process.sleep(@scrape_interval_ms)
 
-    series = Charts.series("device.temp.celsius", :last_value, %{}, mobius_instance: instance)
+    assert {:ok, series} =
+             Charts.series("device.temp.celsius", :last_value, %{}, mobius_instance: instance)
 
     assert series.metric == "device.temp.celsius"
     assert series.type == :last_value


### PR DESCRIPTION
Closes #124

`Charts.series/4` crashed where `Mobius.Data` promises error tuples: the generic clause pattern-matched `{:ok, rows}` on `Data.metrics/4` (MatchError on `{:error, :unavailable}`), the summary clauses called `Data.summary_deltas/5` with no `catch :exit`, and an unknown summary field like `{:summary, :p99}` fell through to the generic clause and yielded rows of nil values that `Plot.line/2` turns into an ArithmeticError.

The first commit deliberately adds failing tests confirming all three crashes; the second commit fixes them.

Contract: `Charts.series/4` now returns `{:ok, series_map} | {:error, :unavailable | term}`, matching its siblings `distribution/3` and `quantiles_over_time/4`. The summary clauses `catch :exit` into `{:error, :unavailable}` the same way `Mobius.Data` does, and a `{:summary, field}` with a field other than `:average`/`:std_dev`/`:reports` returns `{:error, {:invalid_summary_field, field}}` before any query runs. Spec and moduledoc updated accordingly.

The plotting work from `move-plotting-to-mobius-module` has since landed on main, so `Mobius.plot/2` is the one caller and is adapted here: the series call moved into its `with`, and `explain/1` gained friendly messages for `:unavailable` and `{:invalid_summary_field, field}`. `Charts.latest/2` behavior is unchanged (it already swallows errors per its docs).

Local gate: `mix format --check-formatted`, `mix credo --strict` (no issues), `mix test` (190 tests, 0 failures), and `mix compile --force --warnings-as-errors` all pass.