### PR TITLE
Propagate event log save errors

### DIFF
--- a/lib/mobius/event_log.ex
+++ b/lib/mobius/event_log.ex
@@ -68,7 +68,7 @@ defmodule Mobius.EventLog do
   The configured compression level for the instance is applied by the events
   server when it writes the file.
   """
-  @spec save([opt()]) :: :ok
+  @spec save([opt()]) :: :ok | {:error, reason :: term()}
   def save(opts \\ []) do
     instance = opts[:instance] || :mobius
 

--- a/lib/mobius/events_server.ex
+++ b/lib/mobius/events_server.ex
@@ -41,7 +41,7 @@ defmodule Mobius.EventsServer do
   @doc """
   Save the event log to disk
   """
-  @spec save(Mobius.instance()) :: :ok
+  @spec save(Mobius.instance()) :: :ok | {:error, reason :: term()}
   def save(instance \\ :mobius) do
     GenServer.call(name(instance), :save)
   end
@@ -221,9 +221,9 @@ defmodule Mobius.EventsServer do
       :ok ->
         :ok
 
-      {:error, reason} ->
+      {:error, reason} = error ->
         Logger.warning("[Mobius]: unable to save event log: #{inspect(reason)}")
-        :ok
+        error
     end
   end
 end

--- a/test/mobius/event_log_test.exs
+++ b/test/mobius/event_log_test.exs
@@ -94,6 +94,23 @@ defmodule Mobius.EventLogTest do
     assert EventLog.list(instance: instance) == events
   end
 
+  @tag :tmp_dir
+  @tag capture_log: true
+  test "save returns an error when the event log cannot be written", %{tmp_dir: tmp_dir} do
+    instance = :event_log_save_error
+
+    start_supervised!({Mobius, mobius_instance: instance, persistence_dir: tmp_dir})
+
+    EventsServer.insert(instance, Event.new("test", "a.b.c", %{a: 1}, %{}, timestamp: 1))
+
+    # A directory sits where the event log file should go, so the final
+    # rename cannot succeed and nothing is persisted.
+    persistence_path = Path.join(tmp_dir, to_string(instance))
+    File.mkdir_p!(Path.join(persistence_path, "event_log"))
+
+    assert {:error, _reason} = EventLog.save(instance: instance)
+  end
+
   test "parse/1 accepts uncompressed v1 payloads (backwards compat)" do
     events = [
       Event.new("test", "a.b.c", 123_123, %{a: 1}, %{}),

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -76,6 +76,37 @@ defmodule MobiusTest do
     assert File.exists?(Path.join(persistence_path, "history"))
   end
 
+  @tag capture_log: true
+  test "save reports an error when only the event log write fails" do
+    persistence_path = Path.join(@persistence_dir, @default_instance_str)
+    {:ok, _pid} = start_supervised({Mobius, @default_args})
+
+    handler_id = "save-event-log-error-test"
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [[:mobius, :save, :stop], [:mobius, :save, :exception]],
+        fn event, _measurements, _metadata, pid -> send(pid, {:telemetry_event, event}) end,
+        self()
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    # A directory sits where the event log file should go, so the metrics
+    # writes succeed but the event log write cannot.
+    File.mkdir_p!(Path.join(persistence_path, "event_log"))
+
+    assert {:error, _reason} = Mobius.save(@default_instance)
+
+    assert_received {:telemetry_event, [:mobius, :save, :exception]}
+    refute_received {:telemetry_event, [:mobius, :save, :stop]}
+
+    # The sibling save paths still persisted their files.
+    assert File.exists?(Path.join(persistence_path, "history"))
+    assert File.exists?(Path.join(persistence_path, "metrics_table"))
+  end
+
   test "boots when a metric's histogram options are invalid, keeping the summary" do
     metrics = [
       Telemetry.Metrics.summary("boot.bad.hist",


### PR DESCRIPTION
Closes #125

The first commit is a deliberately failing test pair confirming the issue: with a directory squatting on the `event_log` path, `Mobius.EventLog.save/1` and `Mobius.save/1` returned `:ok` (and emitted `[:mobius, :save, :stop]` telemetry) even though the event log write failed.

The fix makes `EventsServer.do_save/2` return the error (still logging the warning), matching the scraper and metrics-table save paths, so `Mobius.save/1` reports the failure through its existing with-chain and emits `[:mobius, :save, :exception]`. The `terminate/2` path stays tolerant, as in the scraper. Specs for `EventLog.save/1` and `EventsServer.save/1` updated to `:ok | {:error, reason}`.

Behavior change: `Mobius.EventLog.save/1` (and therefore `Mobius.save/1`) now returns `{:error, reason}` when the event log cannot be written, where it previously returned `:ok`. `Mobius.AutoSave` already discards the result.

This repository has no CI workflows, so the gate is the local run: `mix format --check-formatted`, `mix credo --strict`, and `mix test` all pass.