### PR TITLE
Make the scrape interval configurable

### DIFF
--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -56,8 +56,10 @@ defmodule Mobius do
      automatic writes of the persistence data (default disabled) metric
      information
   * `:scrape_interval` - time in milliseconds between scrapes of the tracked
-     metrics into the history (defaults to `1_000`). Must be a positive
-     integer; invalid values fall back to the default with a logged warning
+     metrics into the history (defaults to `1_000`). The history stores at
+     most one snapshot per second, so values below `1_000` are clamped to
+     `1_000` with a logged warning; other invalid values fall back to the
+     default. The first scrape runs immediately at startup
   * `:compression_level` - the zlib level (`0..9`) used when compressing
      persisted metric history and event log data. Higher levels trade more CPU
      at save time for smaller files. Defaults to `9` (maximum compression). `0`

--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -55,6 +55,9 @@ defmodule Mobius do
   * `:autosave_interval` - time in seconds (a positive integer) between
      automatic writes of the persistence data (default disabled) metric
      information
+  * `:scrape_interval` - time in milliseconds between scrapes of the tracked
+     metrics into the history (defaults to `1_000`). Must be a positive
+     integer; invalid values fall back to the default with a logged warning
   * `:compression_level` - the zlib level (`0..9`) used when compressing
      persisted metric history and event log data. Higher levels trade more CPU
      at save time for smaller files. Defaults to `9` (maximum compression). `0`
@@ -80,6 +83,7 @@ defmodule Mobius do
           | {:metrics, [Metrics.t()]}
           | {:persistence_dir, binary()}
           | {:autosave_interval, non_neg_integer() | nil}
+          | {:scrape_interval, pos_integer()}
           | {:compression_level, 0..9}
           | {:database, Mobius.RRD.t()}
           | {:events, [event_def()]}

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -7,7 +7,7 @@ defmodule Mobius.Scraper do
 
   require Logger
 
-  @interval 1_000
+  @default_interval 1_000
   @file_name "history"
 
   @doc """
@@ -56,7 +56,7 @@ defmodule Mobius.Scraper do
 
   @impl GenServer
   def init(args) do
-    _ = :timer.send_interval(@interval, self(), :scrape)
+    _ = :timer.send_interval(scrape_interval(args[:scrape_interval]), self(), :scrape)
     Process.flag(:trap_exit, true)
 
     state =
@@ -65,6 +65,19 @@ defmodule Mobius.Scraper do
       |> make_database(args)
 
     {:ok, state}
+  end
+
+  defp scrape_interval(nil), do: @default_interval
+
+  defp scrape_interval(interval) when is_integer(interval) and interval > 0, do: interval
+
+  defp scrape_interval(bad_interval) do
+    Logger.warning(
+      "[Mobius] Ignoring invalid :scrape_interval #{inspect(bad_interval)}, " <>
+        "using #{@default_interval} ms"
+    )
+
+    @default_interval
   end
 
   defp state_from_args(args) do

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -10,9 +10,8 @@ defmodule Mobius.Scraper do
   @default_interval 1_000
   @file_name "history"
 
-  # The RRD keys snapshots by unix second and drops a second snapshot for the
-  # same second, so scraping faster than once a second only builds snapshots
-  # that get thrown away. Sub-second intervals clamp to this floor.
+  # The RRD stores at most one snapshot per second, so sub-second scraping
+  # only builds snapshots that get dropped.
   @min_interval 1_000
 
   @doc """
@@ -62,8 +61,7 @@ defmodule Mobius.Scraper do
   @impl GenServer
   def init(args) do
     _ = :timer.send_interval(scrape_interval(args[:scrape_interval]), self(), :scrape)
-    # Capture a snapshot right away instead of waiting out the first interval,
-    # so a freshly booted instance has data as soon as metrics arrive.
+    # A fresh boot gets a data point right away, not a full interval later.
     send(self(), :scrape)
     Process.flag(:trap_exit, true)
 

--- a/lib/mobius/scraper.ex
+++ b/lib/mobius/scraper.ex
@@ -10,6 +10,11 @@ defmodule Mobius.Scraper do
   @default_interval 1_000
   @file_name "history"
 
+  # The RRD keys snapshots by unix second and drops a second snapshot for the
+  # same second, so scraping faster than once a second only builds snapshots
+  # that get thrown away. Sub-second intervals clamp to this floor.
+  @min_interval 1_000
+
   @doc """
   Start the scraper server
   """
@@ -57,6 +62,9 @@ defmodule Mobius.Scraper do
   @impl GenServer
   def init(args) do
     _ = :timer.send_interval(scrape_interval(args[:scrape_interval]), self(), :scrape)
+    # Capture a snapshot right away instead of waiting out the first interval,
+    # so a freshly booted instance has data as soon as metrics arrive.
+    send(self(), :scrape)
     Process.flag(:trap_exit, true)
 
     state =
@@ -69,7 +77,17 @@ defmodule Mobius.Scraper do
 
   defp scrape_interval(nil), do: @default_interval
 
-  defp scrape_interval(interval) when is_integer(interval) and interval > 0, do: interval
+  defp scrape_interval(interval) when is_integer(interval) and interval >= @min_interval,
+    do: interval
+
+  defp scrape_interval(interval) when is_integer(interval) and interval > 0 do
+    Logger.warning(
+      "[Mobius] :scrape_interval #{interval} ms is below the #{@min_interval} ms floor " <>
+        "(the history stores at most one snapshot per second), using #{@min_interval} ms"
+    )
+
+    @min_interval
+  end
 
   defp scrape_interval(bad_interval) do
     Logger.warning(

--- a/test/mobius/scraper_test.exs
+++ b/test/mobius/scraper_test.exs
@@ -39,7 +39,7 @@ defmodule Mobius.ScraperTest do
     {_pid, ^instance} =
       start_scraper(instance, persistence_dir, RRD.new(@rrd_args), scrape_interval: 50)
 
-    MetricsTable.put(instance, "scrape.interval.test", :last_value, 42)
+    MetricsTable.put(instance, [:scrape, :interval, :test], :last_value, 42)
 
     # With a 50 ms interval the first scrape lands well within 500 ms; the
     # default 1 s interval would still be waiting for its first tick.

--- a/test/mobius/scraper_test.exs
+++ b/test/mobius/scraper_test.exs
@@ -33,19 +33,40 @@ defmodule Mobius.ScraperTest do
     {pid, instance}
   end
 
-  test "scrapes at the configured :scrape_interval", %{persistence_dir: persistence_dir} do
-    instance = :scraper_fast_interval
+  test "scrapes immediately at start instead of waiting an interval", %{
+    persistence_dir: persistence_dir
+  } do
+    instance = :scraper_immediate
+    MetricsTable.init(mobius_instance: instance, persistence_dir: persistence_dir)
+    MetricsTable.put(instance, [:scrape, :immediate, :test], :last_value, 42)
 
-    {_pid, ^instance} =
-      start_scraper(instance, persistence_dir, RRD.new(@rrd_args), scrape_interval: 50)
+    {_pid, ^instance} = start_scraper(instance, persistence_dir, RRD.new(@rrd_args))
 
-    MetricsTable.put(instance, [:scrape, :interval, :test], :last_value, 42)
-
-    # With a 50 ms interval the first scrape lands well within 500 ms; the
-    # default 1 s interval would still be waiting for its first tick.
+    # The boot-time scrape captures the table right away; the first timer
+    # tick would otherwise only land after a full interval (1 s by default).
     records = poll_for_records(instance, 500)
 
-    assert [{_ts, {"scrape.interval.test", :last_value, 42, %{}}} | _rest] = records
+    assert [{_ts, {"scrape.immediate.test", :last_value, 42, %{}}} | _rest] = records
+  end
+
+  test "clamps a sub-second :scrape_interval to the one-second floor", %{
+    persistence_dir: persistence_dir
+  } do
+    instance = :scraper_clamped_interval
+    MetricsTable.init(mobius_instance: instance, persistence_dir: persistence_dir)
+    MetricsTable.put(instance, [:scrape, :clamp, :test], :last_value, 1)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        {_pid, ^instance} =
+          start_scraper(instance, persistence_dir, RRD.new(@rrd_args), scrape_interval: 50)
+
+        # Data still appears promptly — from the boot-time scrape, not from
+        # sub-second ticking, which the RRD would drop anyway.
+        assert [_ | _] = poll_for_records(instance, 500)
+      end)
+
+    assert log =~ "below the 1000 ms floor"
   end
 
   defp poll_for_records(instance, timeout_ms) do

--- a/test/mobius/scraper_test.exs
+++ b/test/mobius/scraper_test.exs
@@ -15,21 +15,48 @@ defmodule Mobius.ScraperTest do
     {:ok, persistence_dir: persistence_dir}
   end
 
-  defp start_scraper(instance, persistence_dir, database) do
+  defp start_scraper(instance, persistence_dir, database, extra_args \\ []) do
     # The scrape timer reads from a metrics table named after the instance, so
     # make sure it exists before the scraper starts.
     if :ets.whereis(instance) == :undefined do
       MetricsTable.init(mobius_instance: instance, persistence_dir: persistence_dir)
     end
 
-    args = [
-      mobius_instance: instance,
-      persistence_dir: persistence_dir,
-      database: database
-    ]
+    args =
+      [
+        mobius_instance: instance,
+        persistence_dir: persistence_dir,
+        database: database
+      ] ++ extra_args
 
     pid = start_supervised!({Scraper, args})
     {pid, instance}
+  end
+
+  test "scrapes at the configured :scrape_interval", %{persistence_dir: persistence_dir} do
+    instance = :scraper_fast_interval
+
+    {_pid, ^instance} =
+      start_scraper(instance, persistence_dir, RRD.new(@rrd_args), scrape_interval: 50)
+
+    MetricsTable.put(instance, "scrape.interval.test", :last_value, 42)
+
+    # With a 50 ms interval the first scrape lands well within 500 ms; the
+    # default 1 s interval would still be waiting for its first tick.
+    records = poll_for_records(instance, 500)
+
+    assert [{_ts, {"scrape.interval.test", :last_value, 42, %{}}} | _rest] = records
+  end
+
+  defp poll_for_records(instance, timeout_ms) do
+    case Scraper.all(instance) do
+      [] when timeout_ms > 0 ->
+        Process.sleep(10)
+        poll_for_records(instance, timeout_ms - 10)
+
+      records ->
+        records
+    end
   end
 
   test "save/1 persists the database so a fresh scraper restores it", %{

--- a/test/mobius/scraper_test.exs
+++ b/test/mobius/scraper_test.exs
@@ -42,8 +42,8 @@ defmodule Mobius.ScraperTest do
 
     {_pid, ^instance} = start_scraper(instance, persistence_dir, RRD.new(@rrd_args))
 
-    # The boot-time scrape captures the table right away; the first timer
-    # tick would otherwise only land after a full interval (1 s by default).
+    # Well under the 1 s first timer tick, so only the boot-time scrape
+    # can satisfy this.
     records = poll_for_records(instance, 500)
 
     assert [{_ts, {"scrape.immediate.test", :last_value, 42, %{}}} | _rest] = records
@@ -61,8 +61,6 @@ defmodule Mobius.ScraperTest do
         {_pid, ^instance} =
           start_scraper(instance, persistence_dir, RRD.new(@rrd_args), scrape_interval: 50)
 
-        # Data still appears promptly — from the boot-time scrape, not from
-        # sub-second ticking, which the RRD would drop anyway.
         assert [_ | _] = poll_for_records(instance, 500)
       end)
 

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -178,7 +178,10 @@ defmodule MobiusTest do
         )
       ]
 
-      {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
+      {:ok, _pid} =
+        start_supervised(
+          {Mobius, Keyword.merge(@default_args, metrics: metrics, scrape_interval: 50)}
+        )
 
       # Record a metric and an event.
       :telemetry.execute([:remove_all_data, :test], %{count: 1}, %{})
@@ -192,8 +195,7 @@ defmodule MobiusTest do
       assert Mobius.MetricsTable.get_entries(instance) != []
 
       # Give the scraper a tick to capture a snapshot into the RRD.
-      Process.sleep(1_100)
-      refute Enum.empty?(Mobius.Scraper.all(instance))
+      refute Enum.empty?(wait_for_scrape(instance))
 
       # The event landed in the event log.
       assert Mobius.EventLog.list(instance: instance) != []
@@ -247,10 +249,11 @@ defmodule MobiusTest do
         )
       ]
 
-      {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
+      args = Keyword.merge(@default_args, metrics: metrics, scrape_interval: 50)
+      {:ok, _pid} = start_supervised({Mobius, args})
 
       :telemetry.execute([:remove_all_data, :save], %{count: 1}, %{})
-      Process.sleep(1_100)
+      refute Enum.empty?(wait_for_scrape(instance))
 
       assert :ok = Mobius.remove_all_data(instance)
       assert :ok = Mobius.save(instance)
@@ -262,10 +265,21 @@ defmodule MobiusTest do
 
       stop_supervised!(Mobius)
 
-      {:ok, _pid} = start_supervised({Mobius, Keyword.put(@default_args, :metrics, metrics)})
+      {:ok, _pid} = start_supervised({Mobius, args})
 
       assert Mobius.MetricsTable.get_entries(instance) == []
       assert Mobius.Scraper.all(instance) == []
+    end
+  end
+
+  defp wait_for_scrape(instance, timeout_ms \\ 1_000) do
+    case Mobius.Scraper.all(instance) do
+      [] when timeout_ms > 0 ->
+        Process.sleep(10)
+        wait_for_scrape(instance, timeout_ms - 10)
+
+      records ->
+        records
     end
   end
 

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -178,10 +178,7 @@ defmodule MobiusTest do
         )
       ]
 
-      {:ok, _pid} =
-        start_supervised(
-          {Mobius, Keyword.merge(@default_args, metrics: metrics, scrape_interval: 50)}
-        )
+      {:ok, _pid} = start_supervised({Mobius, Keyword.merge(@default_args, metrics: metrics)})
 
       # Record a metric and an event.
       :telemetry.execute([:remove_all_data, :test], %{count: 1}, %{})
@@ -249,7 +246,7 @@ defmodule MobiusTest do
         )
       ]
 
-      args = Keyword.merge(@default_args, metrics: metrics, scrape_interval: 50)
+      args = Keyword.merge(@default_args, metrics: metrics)
       {:ok, _pid} = start_supervised({Mobius, args})
 
       :telemetry.execute([:remove_all_data, :save], %{count: 1}, %{})
@@ -272,7 +269,9 @@ defmodule MobiusTest do
     end
   end
 
-  defp wait_for_scrape(instance, timeout_ms \\ 1_000) do
+  # The metric lands at the first scrape tick after its telemetry event, up
+  # to one scrape interval (1 s) later — poll with margin for slow CI.
+  defp wait_for_scrape(instance, timeout_ms \\ 2_500) do
     case Mobius.Scraper.all(instance) do
       [] when timeout_ms > 0 ->
         Process.sleep(10)


### PR DESCRIPTION
Closes #130

The first commit is a deliberately failing test demonstrating the missing capability: a Scraper started with `scrape_interval: 50` should capture a tracked metric within 500 ms, but the option was ignored and the first scrape only happened at the hardcoded 1 s tick.

The second commit adds the `:scrape_interval` argument (milliseconds, default 1_000) and documents it in the `Mobius.arg()` typedoc.

The third commit amends the semantics per review: the RRD stores at most one snapshot per second, so sub-second intervals could never add data — they now clamp to a documented 1000 ms floor with a logged warning, and the Scraper sends itself an immediate first `:scrape` at init so a fresh instance has data right away (this is also where the test speedup honestly comes from). The slow `remove_all_data` tests poll with `wait_for_scrape` instead of sleeping through the tick.

(The branch previously carried a `String.to_atom` credo cleanup in the touched test file; that fix landed on main via #145, so the commit was dropped during rebase.)

Local gate: `mix format --check-formatted`, `mix credo --strict`, and `mix test` (213 tests, 0 failures) all pass, plus `mix compile --warnings-as-errors` on Elixir 1.20.0-rc.1. The 1.20 CI job's credo step currently fails on a `Module.concat` finding inherited from main; #147 fixes that on main.
