### PR TITLE
Fix documentation and typespec drift

### DIFF
--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -44,7 +44,7 @@ defmodule Mobius do
   @type event_opt() ::
           {:measurement_values, event_measurement_values()} | {:tags, [atom()]} | {:group, atom()}
 
-  @type event_def() :: [binary() | {binary(), keyword()}]
+  @type event_def() :: binary() | {binary(), keyword()}
 
   @typedoc """
   Arguments to Mobius
@@ -78,6 +78,7 @@ defmodule Mobius do
           {:mobius_instance, instance()}
           | {:metrics, [Metrics.t()]}
           | {:persistence_dir, binary()}
+          | {:autosave_interval, non_neg_integer() | nil}
           | {:compression_level, 0..9}
           | {:database, Mobius.RRD.t()}
           | {:events, [event_def()]}
@@ -280,8 +281,8 @@ defmodule Mobius do
 
         :telemetry.execute(
           prefix ++ [:exception],
-          %{reason: inspect(error), duration: duration},
-          %{instance: instance}
+          %{duration: duration},
+          %{instance: instance, reason: inspect(error)}
         )
 
         error

--- a/lib/mobius/data/metrics.ex
+++ b/lib/mobius/data/metrics.ex
@@ -39,6 +39,7 @@ defmodule Mobius.Data.Metrics do
       mobius_instance: mobius_instance,
       metric_name: metric_name,
       tags: tags,
+      type: type,
       opts: scraper_opts
     })
 

--- a/lib/mobius/events.ex
+++ b/lib/mobius/events.ex
@@ -13,10 +13,12 @@ defmodule Mobius.Events do
 
   * `:table` - the metrics table name used to store metrics
   * `:event_opts` - the list of options to configure the event
+  * `:session` - the session the event is recorded under
   """
   @type event_handler_config() :: %{
           table: Mobius.instance(),
-          metrics: [Metrics.t()]
+          event_opts: keyword(),
+          session: Mobius.session()
         }
 
   @typedoc """

--- a/lib/mobius/exports.ex
+++ b/lib/mobius/exports.ex
@@ -22,7 +22,7 @@ defmodule Mobius.Exports do
 
   * `:mobius_instance` - the name of the Mobius instance you are using. Unless
     you specified this in your configuration you should be safe to allow this
-    option to default, which is `:mobius_metrics`.
+    option to default, which is `:mobius`.
   * `:last` - display data point that have been captured over the last `x`
     amount of time. Where `x` is either an integer or a tuple of
     `{integer(), time_unit()}`. If you only pass an integer the time unit of
@@ -66,7 +66,7 @@ defmodule Mobius.Exports do
   Mobius.Exports.csv("vm.memory.total", :last_value, %{}, iodevice: :stdio)
 
   # Write to a file
-  file = File.open("mycsv.csv", [:write])
+  {:ok, file} = File.open("mycsv.csv", [:write])
   :ok = Mobius.Exports.csv("vm.memory.total", :last_value, %{}, iodevice: file)
   ```
   """
@@ -87,7 +87,7 @@ defmodule Mobius.Exports do
   @doc """
   Generates a series that contains the value of the metric
   """
-  @spec series(String.t(), export_metric_type(), map(), [export_opt()]) :: [integer()]
+  @spec series(String.t(), export_metric_type(), map(), [export_opt()]) :: [term()]
   def series(metric_name, type, tags, opts \\ []) do
     metric_name
     |> get_metrics(type, tags, opts)
@@ -149,7 +149,7 @@ defmodule Mobius.Exports do
     filter_metrics_opts =
       opts
       |> Keyword.put_new(:mobius_instance, :mobius)
-      |> Keyword.take([:metic_name, :type, :tags, :mobius_instance, :from, :to, :last])
+      |> Keyword.take([:type, :tags, :mobius_instance, :from, :to, :last])
 
     metrics(metric_name, type, tags, filter_metrics_opts)
   end
@@ -188,13 +188,13 @@ defmodule Mobius.Exports do
   Plotting data over the last 30 seconds:
 
   ```elixir
-  Mobius.Export.plot("vm.memory.total", :last_value, %{}, last: 30)
+  Mobius.Exports.plot("vm.memory.total", :last_value, %{}, last: 30)
   ```
 
   Plotting data over the last 2 hours:
 
   ```elixir
-  Mobius.Export.plot("vm.memory.total", :last_value, %{}, last: {2, :hour})
+  Mobius.Exports.plot("vm.memory.total", :last_value, %{}, last: {2, :hour})
   ```
 
   Retrieving summary data can be performed by specifying type of the form:
@@ -218,7 +218,7 @@ defmodule Mobius.Exports do
     Mobius.plot(metric_name, Keyword.merge(opts, type: type, tags: tags))
   end
 
-  @type mfb_export_opt() :: {:out_dir, Path.t()} | export_opt()
+  @type mbf_export_opt() :: {:out_dir, Path.t()} | export_opt()
 
   @doc """
   Export all metrics in the Mobius Binary Format (MBF)
@@ -246,7 +246,7 @@ defmodule Mobius.Exports do
 
   See `Mobius.Exports.parse_mbf/1` to parse a binary in MBF.
   """
-  @spec mbf([mfb_export_opt()]) :: binary() | {:ok, Path.t()} | {:error, Mobius.FileError.t()}
+  @spec mbf([mbf_export_opt()]) :: binary() | {:ok, Path.t()} | {:error, Mobius.FileError.t()}
   def mbf(opts \\ []) do
     mobius_instance = opts[:mobius_instance] || :mobius
 

--- a/lib/mobius/metrics_table.ex
+++ b/lib/mobius/metrics_table.ex
@@ -8,9 +8,14 @@ defmodule Mobius.MetricsTable do
 
   @typedoc """
   A single entry of a metric in the metric table
+
+  The name is the dotted string form of the metric name. The type is either
+  one of the regular metric types or a histogram bin key, and the value
+  depends on the type — for example an integer for counters and a
+  `Mobius.Summary.data()` map for summaries.
   """
   @type metric_entry() ::
-          {Mobius.metric_name(), Mobius.metric_type(), integer(), map()}
+          {Mobius.metric_name(), Mobius.metric_type() | Mobius.DDSketch.bin_key(), term(), map()}
 
   require Logger
 

--- a/lib/mobius/summary.ex
+++ b/lib/mobius/summary.ex
@@ -53,7 +53,7 @@ defmodule Mobius.Summary do
     }
   end
 
-  defp std_dev(_sum, _sum_sqrd, 1), do: 0
+  defp std_dev(_sum, _sum_sqrd, 1), do: 0.0
 
   # Naive algorithm. See Wikipedia. Clamp the operand at 0 before sqrt: the
   # naive sum-of-squares variance can lose precision and go slightly negative

--- a/test/mobius/summary_test.exs
+++ b/test/mobius/summary_test.exs
@@ -34,6 +34,15 @@ defmodule Mobius.SummaryTest do
     assert expected_summary == Summary.calculate(summary_data)
   end
 
+  # `Summary.t()` types `:std_dev` as `float()`, so a single-report summary
+  # must produce `0.0` rather than the integer `0`.
+  test "calculate returns a float std_dev for a single report" do
+    summary = 100 |> Summary.new() |> Summary.calculate()
+
+    assert is_float(summary.std_dev)
+    assert summary.std_dev == 0.0
+  end
+
   test "calculate exposes the report count as the subgroup size" do
     summary_data =
       100

--- a/test/mobius/telemetry_test.exs
+++ b/test/mobius/telemetry_test.exs
@@ -1,0 +1,72 @@
+defmodule Mobius.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  # Telemetry convention: measurements carry numeric values, while contextual
+  # identifiers (metric type, failure reason, instance) belong in metadata.
+
+  describe "[:mobius, :export, :metrics, :stop]" do
+    @tag :tmp_dir
+    test "carries the metric type in the stop metadata", %{tmp_dir: tmp_dir} do
+      instance = :telemetry_export_stop
+      handler_id = {__MODULE__, :export_stop}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:mobius, :export, :metrics, :stop],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:export_stop, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {:ok, _} =
+        start_supervised(
+          {Mobius, mobius_instance: instance, persistence_dir: tmp_dir, metrics: []}
+        )
+
+      _rows =
+        Mobius.Exports.metrics("vm.memory.total", :last_value, %{}, mobius_instance: instance)
+
+      assert_receive {:export_stop, %{duration: _}, %{mobius_instance: ^instance} = metadata}
+      assert metadata[:type] == :last_value
+    end
+  end
+
+  describe "[:mobius, :save, :exception]" do
+    @tag :tmp_dir
+    @tag capture_log: true
+    test "puts the failure reason in the metadata", %{tmp_dir: tmp_dir} do
+      instance = :telemetry_save_exception
+      handler_id = {__MODULE__, :save_exception}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:mobius, :save, :exception],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:save_exception, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # A file occupies the persistence path, so every save attempt fails.
+      bad_parent = Path.join(tmp_dir, "not_a_dir")
+      File.write!(bad_parent, "occupied")
+
+      {:ok, _} =
+        start_supervised(
+          {Mobius, mobius_instance: instance, persistence_dir: bad_parent, metrics: []}
+        )
+
+      assert {:error, _reason} = Mobius.save(instance)
+
+      assert_receive {:save_exception, %{duration: _}, %{instance: ^instance} = metadata}
+      assert metadata[:reason]
+    end
+  end
+end

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -132,7 +132,7 @@ defmodule MobiusTest do
   describe "remove_all_data/1" do
     test "clears in-memory metrics, history, the event log, and persisted files" do
       persistence_path = Path.join(@persistence_dir, @default_instance_str)
-      instance = String.to_atom(@default_instance_str)
+      instance = @default_instance
 
       metrics = [
         Telemetry.Metrics.counter("remove_all_data.test.count",
@@ -179,7 +179,7 @@ defmodule MobiusTest do
     end
 
     test "keeps tracking configured metrics after removing all data" do
-      instance = String.to_atom(@default_instance_str)
+      instance = @default_instance
 
       metrics = [
         Telemetry.Metrics.counter("remove_all_data.again.count",
@@ -201,7 +201,7 @@ defmodule MobiusTest do
     end
 
     test "a later save does not resurrect cleared data" do
-      instance = String.to_atom(@default_instance_str)
+      instance = @default_instance
 
       metrics = [
         Telemetry.Metrics.counter("remove_all_data.save.count",


### PR DESCRIPTION
Closes #129

The first commit adds deliberately failing tests for the testable subset of the issue: `Summary.calculate/1` returning an integer `std_dev` of `0` for a single report (the type says `float()`), the `[:mobius, :export, :metrics, :stop]` metadata dropping `:type` (present on `:start`), and `[:mobius, :save, :exception]` carrying `reason` in measurements instead of metadata. The second commit fixes those three plus the remaining doc/spec-only drift (Exports docs/types, `Mobius.arg()`/`event_def()`, `Events.event_handler_config()`, `MetricsTable.metric_entry()`).

A third commit fixes three pre-existing `Credo.Check.Warning.UnsafeToAtom` hits in `test/mobius_test.exs` that have made `mix credo --strict` red on main since #111 enabled the check (main's latest 1.20 CI job fails on exactly these) — the sites just use the existing `@default_instance` attribute now.

Deliberately skipped: the README bullet about plotting. The `Mobius.metrics/1`/`current/2`/`plot/2` conveniences landed on main with the plotting move, but reworking the README around them belongs with that plotting work, not this drift cleanup.

Local gate: `mix format --check-formatted`, `mix credo --strict`, `mix test` (190 tests, 0 failures), and `mix dialyzer` all pass. CircleCI: 4 of 6 jobs green; the 1.17.3 and 1.20.0 jobs both failed on the pre-existing timing flake `can autosave persistence data` (test/mobius_test.exs:121 sleeps 1.1 s waiting on a 1 s autosave), which this branch does not touch — a rerun should clear them.