### PR TITLE
Fix assorted small defects

### DIFF
--- a/lib/mobius.ex
+++ b/lib/mobius.ex
@@ -52,8 +52,9 @@ defmodule Mobius do
   * `:name` - the name of the mobius instance (defaults to `:mobius`)
   * `:metrics` - list of telemetry metrics for Mobius to track
   * `:persistence_dir` - the top level directory where mobius will persist
-  * `:autosave_interval` - time in seconds between automatic writes of the
-     persistence data (default disabled) metric information
+  * `:autosave_interval` - time in seconds (a positive integer) between
+     automatic writes of the persistence data (default disabled) metric
+     information
   * `:compression_level` - the zlib level (`0..9`) used when compressing
      persisted metric history and event log data. Higher levels trade more CPU
      at save time for smaller files. Defaults to `9` (maximum compression). `0`
@@ -204,10 +205,23 @@ defmodule Mobius do
   end
 
   defp maybe_enable_autosave(children, args) do
-    if is_number(args[:autosave_interval]) and args[:autosave_interval] > 0 do
-      children ++ [{Mobius.AutoSave, args}]
-    else
-      children
+    case args[:autosave_interval] do
+      nil ->
+        children
+
+      interval when is_integer(interval) and interval > 0 ->
+        children ++ [{Mobius.AutoSave, args}]
+
+      invalid ->
+        # A float would make :timer.send_interval/3 return {:error, :badarg},
+        # silently disabling autosave while looking enabled — reject anything
+        # but a positive integer up front, but don't prevent boot over it.
+        Logger.warning(
+          "[Mobius] ignoring invalid autosave_interval #{inspect(invalid)}; " <>
+            "expected a positive integer number of seconds, autosave is disabled"
+        )
+
+        children
     end
   end
 

--- a/lib/mobius/exceptions.ex
+++ b/lib/mobius/exceptions.ex
@@ -96,7 +96,7 @@ defmodule Mobius.FileError do
     %__MODULE__{
       error: error,
       message:
-        "Could not #{inspect(operation)} file #{inspect(file)} for reason: {inspect(error)}",
+        "Could not #{inspect(operation)} file #{inspect(file)} for reason: #{inspect(error)}",
       file: file,
       operation: operation
     }

--- a/lib/mobius/exports/csv.ex
+++ b/lib/mobius/exports/csv.ex
@@ -10,7 +10,7 @@ defmodule Mobius.Exports.CSV do
   @doc """
   Export metrics to a CSV
   """
-  @spec export_metrics([Mobius.metric()], [export_opt()]) :: :ok | String.t()
+  @spec export_metrics([Mobius.metric()], [export_opt()]) :: :ok | {:ok, binary()}
   def export_metrics(metrics, opts \\ []) do
     tag_names = Keyword.fetch!(opts, :tags)
     metric_name = Keyword.fetch!(opts, :metric_name)
@@ -18,7 +18,9 @@ defmodule Mobius.Exports.CSV do
     headers = make_csv_headers(tag_names, opts)
     rows = format_metrics_as_csv(metrics, metric_name, tag_names)
 
-    write_csv([headers | rows], opts)
+    csv_rows = if headers == [], do: rows, else: [headers | rows]
+
+    write_csv(csv_rows, opts)
   end
 
   defp make_csv_headers(extra_tag_headers, opts) do
@@ -53,13 +55,25 @@ defmodule Mobius.Exports.CSV do
   defp write_csv(csv_content, opts) do
     case opts[:iodevice] do
       nil ->
-        {:ok,
-         csv_content
-         |> Enum.map_join("\n", &Enum.join(&1, ","))
-         |> String.trim("\n")}
+        {:ok, Enum.map_join(csv_content, "\n", &format_row/1)}
 
       device ->
-        Enum.each(csv_content, fn row -> IO.write(device, [Enum.intersperse(row, ","), "\n"]) end)
+        Enum.each(csv_content, fn row -> IO.write(device, [format_row(row), "\n"]) end)
+    end
+  end
+
+  defp format_row(row) do
+    Enum.map_join(row, ",", &escape_field/1)
+  end
+
+  # RFC 4180-style quoting: fields containing the separator, a double quote,
+  # or a line break are wrapped in double quotes, with embedded double quotes
+  # doubled.
+  defp escape_field(field) do
+    if String.contains?(field, [",", "\"", "\n", "\r"]) do
+      "\"" <> String.replace(field, "\"", "\"\"") <> "\""
+    else
+      field
     end
   end
 end

--- a/lib/mobius/metrics_table.ex
+++ b/lib/mobius/metrics_table.ex
@@ -168,8 +168,13 @@ defmodule Mobius.MetricsTable do
     path = Path.join(persistence_dir, "metrics_table")
     tmp = path <> ".tmp"
 
-    with :ok <- :ets.tab2file(instance, String.to_charlist(tmp), sync: true) do
-      File.rename(tmp, path)
+    with :ok <- :ets.tab2file(instance, String.to_charlist(tmp), sync: true),
+         :ok <- File.rename(tmp, path) do
+      :ok
+    else
+      error ->
+        _ = File.rm(tmp)
+        error
     end
   end
 

--- a/lib/mobius/report_server.ex
+++ b/lib/mobius/report_server.ex
@@ -62,22 +62,25 @@ defmodule Mobius.ReportServer do
   end
 
   defp get_query_window(%{events_next_start: nil}, :events) do
-    {0, now()}
+    {0, last_closed_second()}
   end
 
   defp get_query_window(state, :events) do
-    {state.events_next_start, now()}
+    {state.events_next_start, last_closed_second()}
   end
 
   defp get_query_window(%{metrics_next_start: nil}, :metrics) do
-    {0, now()}
+    {0, last_closed_second()}
   end
 
   defp get_query_window(state, :metrics) do
-    {state.metrics_next_start, now()}
+    {state.metrics_next_start, last_closed_second()}
   end
 
-  defp now() do
-    System.system_time(:second)
+  # Only query up to the previous (closed) second. Records can still land in
+  # the current second after this query has run, and since the next window
+  # starts at `to + 1` they would be skipped permanently.
+  defp last_closed_second() do
+    System.system_time(:second) - 1
   end
 end

--- a/test/mobius/exceptions_test.exs
+++ b/test/mobius/exceptions_test.exs
@@ -1,0 +1,14 @@
+defmodule Mobius.ExceptionsTest do
+  use ExUnit.Case, async: true
+
+  describe "Mobius.FileError" do
+    test "message contains the inspected error reason" do
+      error =
+        Mobius.FileError.exception(error: :enoent, file: "/data/history", operation: "read")
+
+      assert error.message =~ ":enoent"
+      assert error.message =~ ~s("read")
+      assert error.message =~ ~s("/data/history")
+    end
+  end
+end

--- a/test/mobius/exports/csv_test.exs
+++ b/test/mobius/exports/csv_test.exs
@@ -64,6 +64,46 @@ defmodule Mobius.Exporters.CSVTest do
     assert csv_string == String.trim(expected_string, "\n")
   end
 
+  test "quotes fields containing commas, quotes, or newlines" do
+    metrics = [
+      %{timestamp: 1, type: :last_value, value: 10, tags: %{extra: "with, comma"}},
+      %{timestamp: 2, type: :last_value, value: 11, tags: %{extra: ~s(say "hi")}},
+      %{timestamp: 3, type: :last_value, value: 12, tags: %{extra: "line\nbreak"}}
+    ]
+
+    {:ok, csv_string} = CSV.export_metrics(metrics, tags: [:extra], metric_name: "test")
+
+    assert csv_string ==
+             Enum.join(
+               [
+                 "timestamp,name,type,value,extra",
+                 ~s(1,test,last_value,10,"with, comma"),
+                 ~s(2,test,last_value,11,"say ""hi"""),
+                 ~s(3,test,last_value,12,"line\nbreak")
+               ],
+               "\n"
+             )
+  end
+
+  test "no headers with an iodevice does not write a leading blank line",
+       %{metrics_no_tags: metrics} do
+    expected_string = """
+    1,test,last_value,10
+    2,test,last_value,13
+    4,test,last_value,15
+    8,test,last_value,16
+    """
+
+    assert capture_io(fn ->
+             CSV.export_metrics(metrics,
+               tags: [],
+               metric_name: "test",
+               headers: false,
+               iodevice: :stdio
+             )
+           end) == expected_string
+  end
+
   test "print to screen", %{metrics_no_tags: metrics} do
     expected_string = """
     timestamp,name,type,value

--- a/test/mobius/metrics/metrics_table_test.exs
+++ b/test/mobius/metrics/metrics_table_test.exs
@@ -126,6 +126,25 @@ defmodule Mobius.Metrics.MetricsTableTest do
              MetricsTable.get_entries_by_metric_name(table, "saved.value")
   end
 
+  test "save/2 removes the tmp file when the save fails" do
+    persistence_dir =
+      Path.join(System.tmp_dir!(), "mobius_save_fail_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(persistence_dir)
+    on_exit(fn -> File.rm_rf!(persistence_dir) end)
+
+    table = :metrics_table_failed_save
+    ^table = MetricsTable.init(mobius_instance: table, persistence_dir: persistence_dir)
+    :ok = MetricsTable.put(table, [:doomed, :value], :last_value, 1)
+
+    # Occupy the destination path with a non-empty directory so the rename
+    # into place fails after the tmp file has been written.
+    File.mkdir_p!(Path.join([persistence_dir, "metrics_table", "occupied"]))
+
+    assert {:error, _reason} = MetricsTable.save(table, persistence_dir)
+    refute File.exists?(Path.join(persistence_dir, "metrics_table.tmp"))
+  end
+
   # Persisted metrics tables from older Mobius versions contain summary entries
   # with `:min` and `:max` keys. Loading those tables must still work — the
   # unused keys should be ignored and subsequent updates should produce the

--- a/test/mobius/report_server_test.exs
+++ b/test/mobius/report_server_test.exs
@@ -1,0 +1,54 @@
+defmodule Mobius.ReportServerTest do
+  use ExUnit.Case, async: false
+
+  alias Mobius.{Event, EventLog, EventsServer, ReportServer}
+
+  @instance :report_server_test
+  @persistence_dir System.tmp_dir!() |> Path.join("mobius_report_server_test")
+
+  setup do
+    File.rm_rf!(@persistence_dir)
+    File.mkdir_p!(@persistence_dir)
+
+    start_supervised!(
+      {Mobius, mobius_instance: @instance, persistence_dir: @persistence_dir, metrics: []}
+    )
+
+    :ok
+  end
+
+  test "an event landing late in the boundary second is not skipped" do
+    # Run a query during a known second so we know which window boundary the
+    # server stored. Retry in the unlikely case the second ticks over mid-call.
+    boundary =
+      Enum.find_value(1..10, fn _ ->
+        pre = System.system_time(:second)
+        _ = ReportServer.get_latest_events(@instance)
+        if System.system_time(:second) == pre, do: pre
+      end)
+
+    assert boundary, "could not run a query within a single second"
+
+    # The event lands in second `boundary` *after* the query above ran.
+    event = Event.new("test", "late.event", %{value: 1}, %{}, timestamp: boundary)
+    :ok = EventsServer.insert(@instance, event)
+
+    # Sanity check: the event is in the event log.
+    assert Enum.any?(EventLog.list(instance: @instance), &(&1.name == "late.event"))
+
+    # Once the boundary second has fully passed, the next report must still
+    # pick the event up — it must not fall between the query windows.
+    wait_until_after(boundary)
+
+    events = ReportServer.get_latest_events(@instance)
+
+    assert Enum.any?(events, &(&1.name == "late.event"))
+  end
+
+  defp wait_until_after(second) do
+    if System.system_time(:second) <= second do
+      Process.sleep(50)
+      wait_until_after(second)
+    end
+  end
+end

--- a/test/mobius_test.exs
+++ b/test/mobius_test.exs
@@ -128,6 +128,20 @@ defmodule MobiusTest do
     assert File.exists?(Path.join(persistence_path, "metrics_table"))
   end
 
+  test "a non-integer autosave_interval disables autosave with a warning" do
+    log =
+      capture_log(fn ->
+        assert {:ok, _pid} = start_supervised({Mobius, @default_args ++ [autosave_interval: 1.5]})
+      end)
+
+    assert log =~ "autosave_interval"
+
+    # The AutoSave server must not be started at all — a float interval makes
+    # :timer.send_interval/3 return {:error, :badarg}, silently disabling
+    # autosave while looking enabled.
+    refute Process.whereis(Module.concat(Mobius.AutoSave, :mobius))
+  end
+
   describe "remove_all_data/1" do
     test "clears in-memory metrics, history, the event log, and persisted files" do
       persistence_path = Path.join(@persistence_dir, @default_instance_str)


### PR DESCRIPTION
Closes #128

The first commit deliberately adds failing tests that confirm each defect on main:

- `Mobius.FileError` message contains the literal text `{inspect(error)}` (missing `#`)
- a float `autosave_interval` silently disables autosave with no warning
- `MetricsTable.save/2` leaves `metrics_table.tmp` behind when the save fails
- `ReportServer` skips records that land in the boundary second after a query ran (`next_start = to + 1`)
- CSV export does no quoting/escaping, and `headers: false` with `:iodevice` writes a leading blank line

Already fixed on main (no test or change needed):

- `EventsServer` clear/reset not emptying `out_of_time_buffer` — fixed by 942e3b5 (the reset feature), which resets both buffers

The follow-up commit fixes the confirmed items, including the `CSV.export_metrics` spec (`:ok | String.t()` -> `:ok | {:ok, binary()}`), which has no runtime test.